### PR TITLE
fix(plugin): stabilize local plugin path validation

### DIFF
--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -349,9 +349,14 @@ func (m *Manager) isPathInAllowedDir(resolvedPath string) bool {
 			continue
 		}
 
+		allowedPath := absAllowed
+		if resolvedAllowed, err := filepath.EvalSymlinks(absAllowed); err == nil {
+			allowedPath = resolvedAllowed
+		}
+
 		// Use filepath.Rel for robust relative path check
 		// This properly handles edge cases like /usr/local/lib/relicta/plugins2
-		rel, err := filepath.Rel(absAllowed, resolvedPath)
+		rel, err := filepath.Rel(allowedPath, resolvedPath)
 		if err != nil {
 			continue
 		}

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -1261,43 +1261,51 @@ func TestIsPathInAllowedDir_LocalPluginDir(t *testing.T) {
 	cfg := &config.Config{}
 	m := NewManager(cfg)
 
-	// Test with local project plugin directory
 	localDir := ".relicta/plugins"
-	os.MkdirAll(localDir, 0755)
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		t.Fatalf("Failed to create local plugin dir: %v", err)
+	}
 	defer os.RemoveAll(".relicta")
 
 	testPath := filepath.Join(localDir, "test-plugin")
+	if err := os.WriteFile(testPath, []byte("#!/bin/bash\necho test"), 0o755); err != nil {
+		t.Fatalf("Failed to create test plugin: %v", err)
+	}
+
 	absPath, err := filepath.Abs(testPath)
 	if err != nil {
 		t.Fatalf("Failed to get absolute path: %v", err)
 	}
+	realPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		t.Fatalf("Failed to resolve symlink path: %v", err)
+	}
 
-	result := m.isPathInAllowedDir(absPath)
-	if !result {
+	if !m.isPathInAllowedDir(realPath) {
 		t.Error("isPathInAllowedDir() should return true for local plugin directory")
 	}
 }
 
 func TestFindPluginBinary_LocalProjectDir(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+	t.Setenv("HOME", tempDir)
+
 	cfg := &config.Config{}
 	m := NewManager(cfg)
 
-	// Create plugin in local project directory
 	localDir := ".relicta/plugins"
-	os.MkdirAll(localDir, 0755)
-	defer os.RemoveAll(".relicta")
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		t.Fatalf("Failed to create local plugin dir: %v", err)
+	}
 
 	pluginName := "localtest"
 	pluginPath := filepath.Join(localDir, pluginName)
-	err := os.WriteFile(pluginPath, []byte("#!/bin/bash\necho test"), 0755)
-	if err != nil {
+	if err := os.WriteFile(pluginPath, []byte("#!/bin/bash\necho test"), 0o755); err != nil {
 		t.Fatalf("Failed to create plugin file: %v", err)
 	}
 
-	pluginCfg := &config.PluginConfig{
-		Name: pluginName,
-	}
-
+	pluginCfg := &config.PluginConfig{Name: pluginName}
 	foundPath, err := m.findPluginBinary(pluginCfg)
 	if err != nil {
 		t.Errorf("findPluginBinary() error = %v", err)


### PR DESCRIPTION
## Summary
- normalize allowed plugin directory paths with `filepath.EvalSymlinks` when available
- prevent false negatives on macOS path aliases (`/var` vs `/private/var`)
- harden local-plugin tests to validate concrete files and resolved paths

## Why
Pre-commit and local unit runs can fail intermittently in plugin path validation because canonicalized plugin paths and allowed directory paths are compared in different forms.

## Testing
- `make lint`
- `go test ./internal/plugin -count=1`
- `go test ./internal/plugin -run 'TestIsPathInAllowedDir_LocalPluginDir|TestFindPluginBinary_LocalProjectDir' -count=50`
