### PR TITLE
ci: fix dangling job reference breaking workflow parse

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -241,7 +241,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: nox-scan-results
-          path: nox-results.json
+          path: findings.json
         if: always()
 
   sbom:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Install security tools
         run: |
-          curl -sSfL "https://github.com/nox-hq/nox/releases/download/v0.7.0/nox_0.7.0_linux_amd64.tar.gz" | tar xz -C /usr/local/bin nox
+          curl -sSfL "https://github.com/nox-hq/nox/releases/download/v1.1.2/nox_1.1.2_linux_amd64.tar.gz" | tar xz -C /usr/local/bin nox
           go install github.com/securego/gosec/v2/cmd/gosec@latest
           go install golang.org/x/vuln/cmd/govulncheck@latest
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -292,7 +292,7 @@ jobs:
   integration:
     name: Integration Tests
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [lint-and-test]
     # Only run on pushes to main (not PRs, to save resources)
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:

--- a/.nox/baseline.json
+++ b/.nox/baseline.json
@@ -2,86 +2,6 @@
   "schema_version": "1.0.0",
   "entries": [
     {
-      "fingerprint": "1104b823f4f6501f9b2df6247d2b44e07d1bddfd9701bbad6727620d2e8d0aa3",
-      "rule_id": "IAC-254",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference pattern, not a hardcoded secret",
-      "created_at": "2026-03-22T10:43:39.456997Z"
-    },
-    {
-      "fingerprint": "03ea5488e4289eb366932a7c9595d2e43548cf2526e8611ecb74cfb7eb9bfd99",
-      "rule_id": "IAC-254",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference pattern, not a hardcoded secret",
-      "created_at": "2026-03-22T10:43:39.476658Z"
-    },
-    {
-      "fingerprint": "8753f743dd4d17dfd580eafc4cd354ffa555fb3183e1d10234a354d8b6179e7e",
-      "rule_id": "IAC-254",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference pattern, not a hardcoded secret",
-      "created_at": "2026-03-22T10:43:39.501474Z"
-    },
-    {
-      "fingerprint": "10cd6b3ef8aa6dacaf82091486731bf9876ba3ac88df4082ff5c5aab723fde6a",
-      "rule_id": "IAC-254",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference pattern, not a hardcoded secret",
-      "created_at": "2026-03-22T10:43:39.522076Z"
-    },
-    {
-      "fingerprint": "12382606cf62ee86ddb93c42788049fea41b5dd0177bf5d61474514f0ccbbc83",
-      "rule_id": "IAC-254",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference pattern, not a hardcoded secret",
-      "created_at": "2026-03-22T10:43:39.5415Z"
-    },
-    {
-      "fingerprint": "94e1d72156a928285104d88b8b427ac5d8587235a4b0d4daa20f86fcf751a752",
-      "rule_id": "IAC-254",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference pattern, not a hardcoded secret",
-      "created_at": "2026-03-22T10:43:39.560082Z"
-    },
-    {
-      "fingerprint": "0fa2f81f13ffcf4e6f4265d0353608c63b7e82ece0e0a39c41136889a732590c",
-      "rule_id": "IAC-254",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference pattern, not a hardcoded secret",
-      "created_at": "2026-03-22T10:43:39.579477Z"
-    },
-    {
-      "fingerprint": "31603ff20b8c0a9486dac662a99f06d4282f4a9254ff08482f2b072f7c15abaa",
-      "rule_id": "IAC-254",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference pattern, not a hardcoded secret",
-      "created_at": "2026-03-22T10:43:39.595558Z"
-    },
-    {
-      "fingerprint": "734e6c9c66d2333801f853da26a3fc4070108fcc4a8815854e1d3b40ed76ccec",
-      "rule_id": "IAC-254",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference pattern, not a hardcoded secret",
-      "created_at": "2026-03-22T10:43:39.601432Z"
-    },
-    {
-      "fingerprint": "ada0a90e988c7867b71d4cb7695e9bf47e7709522c220953f2872828f4191d9b",
-      "rule_id": "IAC-254",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference pattern, not a hardcoded secret",
-      "created_at": "2026-03-22T10:43:39.630134Z"
-    },
-    {
       "fingerprint": "1a538cb34ae0f49d5c68fe1240b24ebf23094b8d6b0054ad89c6766a9153c400",
       "rule_id": "IAC-351",
       "file_path": ".github/workflows/release.yaml",
@@ -90,515 +10,11 @@
       "created_at": "2026-03-22T10:43:49.18819Z"
     },
     {
-      "fingerprint": "ef75a84c119ea355ac4196183ef53d36aac25de45f7d19b7de0fce2482e29a0f",
-      "rule_id": "IAC-351",
-      "file_path": "docs/security/plugin-release-workflow.yaml",
-      "severity": "critical",
-      "reason": "Documentation template: example workflow config, not a real secret",
-      "created_at": "2026-03-22T10:43:52.295919Z"
-    },
-    {
-      "fingerprint": "3a12e6d2015ad14ba5a37fa5e888552094cb5022455c07520c4f17fefbdec4fd",
-      "rule_id": "IAC-351",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference in config template",
-      "created_at": "2026-03-22T10:43:54.949902Z"
-    },
-    {
-      "fingerprint": "1383c10cac6a979eab77229dfb3d547f26b27b28fc58adfe25e0f1cf3145cef7",
-      "rule_id": "IAC-351",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference in config template",
-      "created_at": "2026-03-22T10:43:57.691302Z"
-    },
-    {
-      "fingerprint": "f04fb70649c36e7be3b877d11df28102e1401ded6667a5891bac4db48db0cbab",
-      "rule_id": "IAC-351",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference in config template",
-      "created_at": "2026-03-22T10:44:00.327133Z"
-    },
-    {
-      "fingerprint": "442bc381b951cdbd83026658d23814613fb7272f669dad855a7c17a4b0cca6f3",
-      "rule_id": "IAC-351",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference in config template",
-      "created_at": "2026-03-22T10:44:03.080121Z"
-    },
-    {
-      "fingerprint": "c59d90e618992a4617bfc4de58f622b6e9a85fc8a07faec69c7339311bcaeafc",
-      "rule_id": "IAC-351",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference in config template",
-      "created_at": "2026-03-22T10:44:05.747202Z"
-    },
-    {
-      "fingerprint": "6ceb08624935666b4cdf8f65b9e5a0754bf3286f91e017e23c26130bac8c62c7",
-      "rule_id": "IAC-351",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference in config template",
-      "created_at": "2026-03-22T10:44:08.803775Z"
-    },
-    {
-      "fingerprint": "0a741d42a3144651c5bb44f1974f3a021ddac4fc175519989b4fa7f9bc2da522",
-      "rule_id": "IAC-351",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference in config template",
-      "created_at": "2026-03-22T10:44:11.489494Z"
-    },
-    {
-      "fingerprint": "33d3279410b4081291df33364b5c764294f9d6d558dfdddfe566b3283c9e2e1c",
-      "rule_id": "IAC-351",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference in config template",
-      "created_at": "2026-03-22T10:44:14.024286Z"
-    },
-    {
-      "fingerprint": "c7de7385f1526eadd21873af76ec50c2050d23746466b8408f107ba48d8e48c6",
-      "rule_id": "AI-022",
-      "file_path": "internal/config/validate_extra_test.go",
-      "severity": "high",
-      "reason": "Test file: intentionally high temperature to test validation logic",
-      "created_at": "2026-03-22T10:44:21.642871Z"
-    },
-    {
-      "fingerprint": "9ab7a8a4d4f5a78443a7cf05bec21ce39da0a18bcccda8c12597c15985ab3290",
-      "rule_id": "AI-007",
-      "file_path": "internal/cli/init.go",
-      "severity": "high",
-      "reason": "Help text placeholder with angle brackets, not an actual key",
-      "created_at": "2026-03-22T10:44:24.4971Z"
-    },
-    {
-      "fingerprint": "bb53c1a274269db86fac37abd416865cb985497cad8feb7008ed3fe90a4dfba0",
-      "rule_id": "IAC-351",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference in config template",
-      "created_at": "2026-03-22T10:44:46.360537Z"
-    },
-    {
-      "fingerprint": "d7c8fbc2be3d62b43d3610956308c7be89402176416e8dead083d3425602850d",
-      "rule_id": "IAC-351",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference in config template",
-      "created_at": "2026-03-22T10:44:48.815832Z"
-    },
-    {
-      "fingerprint": "19cea877a4f37ea8c67e77a5a6f1fce51c756dbd04d9330f8a9ea0ab77b2563a",
-      "rule_id": "IAC-351",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference in config template",
-      "created_at": "2026-03-22T10:44:51.991257Z"
-    },
-    {
-      "fingerprint": "f0d8953cb7702a566d5fa3b0f52299e180abf41c5f5172144db5b3cd322b0529",
-      "rule_id": "IAC-351",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference in config template",
-      "created_at": "2026-03-22T10:44:54.650932Z"
-    },
-    {
-      "fingerprint": "511997589c2b7f548f08a6aa98d9974688837cbd370c042abfe12f5f6a350f7f",
-      "rule_id": "IAC-351",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry schema: env var reference in config template",
-      "created_at": "2026-03-22T10:44:56.960506Z"
-    },
-    {
-      "fingerprint": "678745e4c11253351a112a7592ed49113092ff2edd2ff0679f584db81e3c2c62",
-      "rule_id": "IAC-351",
-      "file_path": "plugins/registry.yaml",
-      "severity": "critical",
-      "reason": "Plugin registry: env var reference, not hardcoded secret",
-      "created_at": "2026-03-22T21:24:42.527157Z"
-    },
-    {
-      "fingerprint": "b92d7097432e2bc22dea8ebdbc1568dabc5b4b4c6946209f66e8224c22075984",
-      "rule_id": "SEC-073",
-      "file_path": "internal/infrastructure/persistence/postgres/postgres_test.go",
-      "severity": "critical",
-      "reason": "Test file: localhost postgres connection string for integration tests",
-      "created_at": "2026-03-22T21:24:45.185519Z"
-    },
-    {
-      "fingerprint": "93e16af35a62de70121aeed769e6c7f625855fbe57b5446aac5f712ab139451f",
-      "rule_id": "SEC-073",
-      "file_path": "internal/infrastructure/persistence/postgres/postgres_test.go",
-      "severity": "critical",
-      "reason": "Test file: localhost postgres connection string for integration tests",
-      "created_at": "2026-03-22T21:24:47.974901Z"
-    },
-    {
-      "fingerprint": "ee2d768304dab5ac753ab91094c1db11237f38b63bd9cfc4078a30971b4e2fbb",
-      "rule_id": "VULN-002",
-      "file_path": "app/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: zod is a legitimate npm package",
-      "created_at": "2026-03-22T21:24:51.771915Z"
-    },
-    {
-      "fingerprint": "9673285bbf42bf305b7c26b1bb48904b5c3235a37115a40daada521fc7ec4f0d",
-      "rule_id": "VULN-002",
-      "file_path": "app/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: qs is a legitimate npm package",
-      "created_at": "2026-03-22T21:24:53.276879Z"
-    },
-    {
-      "fingerprint": "952a871461479d9524da60e70ac847cf96218d0435ceecbb73624b6d8e85ca10",
-      "rule_id": "VULN-002",
-      "file_path": "app/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: vue is a legitimate npm package",
-      "created_at": "2026-03-22T21:24:56.018011Z"
-    },
-    {
-      "fingerprint": "2cd6ad579589c6b65b49ac60bd8fac8003c6a11d3c2a58ecef8051ac1d7fa218",
-      "rule_id": "VULN-002",
-      "file_path": "app/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: he is a legitimate npm HTML entity encoder",
-      "created_at": "2026-03-22T21:24:58.420815Z"
-    },
-    {
-      "fingerprint": "255636a70fab477b61d637306696f6cb3b9436e61ee4687f1ba9a1782d433cd0",
-      "rule_id": "VULN-002",
-      "file_path": "app/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: send is a legitimate npm package by TJ",
-      "created_at": "2026-03-22T21:25:01.656302Z"
-    },
-    {
-      "fingerprint": "dfc5210a27fe0d7676e64f7faa873102c8bd990bfbd4239bbcd3497bb83808d2",
-      "rule_id": "VULN-002",
-      "file_path": "app/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: jiti is a legitimate npm runtime transformer",
-      "created_at": "2026-03-22T21:25:04.124929Z"
-    },
-    {
-      "fingerprint": "ca53bbc4f16283da200844833d5b1e04b9fd5c8ad30821b6c920f774810bd64b",
-      "rule_id": "VULN-002",
-      "file_path": "app/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: ms is a legitimate npm millisecond converter",
-      "created_at": "2026-03-22T21:25:06.377205Z"
-    },
-    {
-      "fingerprint": "11251ff0610c04155ab46df0c32bc879828c9b08f38e316505787eb0000c0f2a",
-      "rule_id": "VULN-002",
-      "file_path": "app/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: jose is a legitimate npm JWT/JOSE library",
-      "created_at": "2026-03-22T21:25:23.933023Z"
-    },
-    {
-      "fingerprint": "d0cd56d4e01e855d2890f54fda5103a281e2402930fcfae68fecdfe0a6e17f46",
-      "rule_id": "VULN-002",
-      "file_path": "app/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: vary is a legitimate npm HTTP Vary header package",
-      "created_at": "2026-03-22T21:25:27.201413Z"
-    },
-    {
-      "fingerprint": "f16a3e9de5edf75b3879ce83603ee6f41dc1c511e167b91709e5bdb3067a5e04",
-      "rule_id": "VULN-002",
-      "file_path": "app/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: safer-buffer is a legitimate npm buffer safety package",
-      "created_at": "2026-03-22T21:25:29.799744Z"
-    },
-    {
-      "fingerprint": "5b38dbdad34e19ce85eb93f530859cc04d8d126d0a9be2540f1f0aa609d7b85c",
-      "rule_id": "VULN-002",
-      "file_path": "app/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: etag is a legitimate npm HTTP ETag package",
-      "created_at": "2026-03-22T21:25:32.933172Z"
-    },
-    {
-      "fingerprint": "1da8a25edbee657256b5a5ae5270e4425dbced6ba1ef4e10cceb173001faa87a",
-      "rule_id": "VULN-002",
-      "file_path": "app/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: ajv is a legitimate npm JSON schema validator",
-      "created_at": "2026-03-22T21:25:35.636427Z"
-    },
-    {
-      "fingerprint": "3b8be86807bbae50e653229b11be1eabaecf8bc7e210a747615ede6cd1d9bfc9",
-      "rule_id": "VULN-002",
-      "file_path": "app/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: gopd is a legitimate npm Object.getOwnPropertyDescriptor package",
-      "created_at": "2026-03-22T21:25:38.802062Z"
-    },
-    {
-      "fingerprint": "25f5a60071edd114960c2cace34679cc51f5a4cc76292e5f39fd49a3de8393e7",
-      "rule_id": "VULN-002",
-      "file_path": "app/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: hono is a legitimate npm web framework",
-      "created_at": "2026-03-22T21:25:41.529276Z"
-    },
-    {
-      "fingerprint": "37dfdd199fcaedec3e984adde717e48ec786efa76c2d84f18cf80dd8759574a1",
-      "rule_id": "VULN-002",
-      "file_path": "web/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: ajv in web/ lockfile is legitimate",
-      "created_at": "2026-03-22T21:25:44.252575Z"
-    },
-    {
-      "fingerprint": "e630fd7a5d806490623b7554032a6a57d881d14f06d61a32b043233b1209541d",
-      "rule_id": "VULN-002",
-      "file_path": "web/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: ms in web/ lockfile is legitimate",
-      "created_at": "2026-03-22T21:25:46.855528Z"
-    },
-    {
-      "fingerprint": "6a793668b0e4bad1046cc1b04db13fc6182a04fb6bcd401c3b7925f65431b2ff",
-      "rule_id": "VULN-002",
-      "file_path": "web/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: defu is a legitimate npm defaults utility",
-      "created_at": "2026-03-22T21:25:49.610944Z"
-    },
-    {
-      "fingerprint": "9bcd19e6ea27b57dd1f76e920d5ceda57fddadcf27313c9758503408da7e5110",
-      "rule_id": "IAC-013",
-      "file_path": "docs/security/plugin-release-workflow.yaml",
-      "severity": "high",
-      "reason": "Documentation template: example workflow, not production CI",
-      "created_at": "2026-03-22T21:26:06.316014Z"
-    },
-    {
-      "fingerprint": "bad4a00cd6c18bc5640b353764811a1d34688d0c90bd9f8a001dc46d30156428",
-      "rule_id": "IAC-013",
-      "file_path": "docs/security/plugin-release-workflow.yaml",
-      "severity": "high",
-      "reason": "Documentation template: example workflow, not production CI",
-      "created_at": "2026-03-22T21:26:09.073344Z"
-    },
-    {
-      "fingerprint": "78c2df5191b1e93bcd1013beb5924487bffa4637cb44d142b9e0ad1f3ffb53c1",
-      "rule_id": "IAC-013",
-      "file_path": "docs/security/plugin-release-workflow.yaml",
-      "severity": "high",
-      "reason": "Documentation template: example workflow, not production CI",
-      "created_at": "2026-03-22T21:26:12.150879Z"
-    },
-    {
-      "fingerprint": "6ab180161732d56fc7a4ec43639816b9c8fddf15b2fe5dbe395c923abe0e2b87",
-      "rule_id": "IAC-013",
-      "file_path": "docs/security/plugin-release-workflow.yaml",
-      "severity": "high",
-      "reason": "Documentation template: example workflow, not production CI",
-      "created_at": "2026-03-22T21:26:12.96648Z"
-    },
-    {
-      "fingerprint": "80615545fce5ffaed55c1fb02d94514be2dd114c616f23893cbc68a5941f7f46",
-      "rule_id": "IAC-013",
-      "file_path": "docs/security/plugin-release-workflow.yaml",
-      "severity": "high",
-      "reason": "Documentation template: example workflow, not production CI",
-      "created_at": "2026-03-22T21:26:13.719025Z"
-    },
-    {
-      "fingerprint": "64ba34970b5f84a397c79843421123b4893aad7a68fb5ca79b1c9270001e1da5",
-      "rule_id": "VULN-002",
-      "file_path": "web/package-lock.json",
-      "severity": "critical",
-      "reason": "False positive: pify is a legitimate npm promisify utility by sindresorhus",
-      "created_at": "2026-03-22T21:26:39.50969Z"
-    },
-    {
-      "fingerprint": "bbb06075c9f61071a4a4c35359bd44ec6a701120b364967f37d76b6c6372d98a",
-      "rule_id": "IAC-013",
-      "file_path": "docs/security/plugin-release-workflow.yaml",
-      "severity": "high",
-      "reason": "Documentation template: example workflow, not production CI",
-      "created_at": "2026-03-22T21:26:41.112906Z"
-    },
-    {
       "fingerprint": "0fda52f1bc9f6ad59c83b1019cb9346bd55305f1712bdeb900417e9a2e1c6a70",
       "rule_id": "AI-008",
       "file_path": "internal/cgp/attribution/detector.go",
       "severity": "medium",
       "reason": "False positive: AI-008 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "690d1fc469cd2c146a214aff95833266a36e39eeec66995c25632c6945092827",
-      "rule_id": "AI-008",
-      "file_path": "internal/config/schema.go",
-      "severity": "medium",
-      "reason": "False positive: AI-008 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "808b737bd2640184666dd0221fcc429192d6929890c7de164dd4d38f9ac853e7",
-      "rule_id": "AI-008",
-      "file_path": "internal/infrastructure/ai/service.go",
-      "severity": "medium",
-      "reason": "False positive: AI-008 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "9ac27d651b2815843e76f14489936d7cf0fdca9f24da9072156076b285bdc7b5",
-      "rule_id": "AI-026",
-      "file_path": "docs/dashboard.md",
-      "severity": "medium",
-      "reason": "False positive: AI-026 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "ba59f27ce3154e60266d92478ca9844eacbd3929becbe5c817581fc1161f52c2",
-      "rule_id": "AI-026",
-      "file_path": "internal/cli/report.go",
-      "severity": "medium",
-      "reason": "False positive: AI-026 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "d14dde879780b12c4299e51784c6f22bad788a9c9164cadb57eddfafbc0e842c",
-      "rule_id": "AI-026",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: AI-026 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "91fea5cfaf1faa1836d9e65f47a5d752cedd49130f9ec70150ff0fa622a1cf9d",
-      "rule_id": "AI-036",
-      "file_path": "CHANGELOG.md",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "46be548ba0f6f6edcb27f0c618232710ac9054ce39340cc8febd941bdccd0d04",
-      "rule_id": "AI-036",
-      "file_path": "docs/ai-providers.md",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "4d03b3ac7da167c06678f2b0c1cc42de2c1aa3b8d8f7e0d326e5ae5126b530a7",
-      "rule_id": "AI-036",
-      "file_path": "docs/ai-providers.md",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "9961be318ebf42b8c4fe239c9f8a45b82adbd3f2aef9fb6b3fa95fd4458af0f0",
-      "rule_id": "AI-036",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "a3ac18778926dd383c60d77ef2d01ad6f7632b262997642a9b0ab77a4feae74b",
-      "rule_id": "AI-036",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "10f72afc95d22541272fe343cdcf6f7019280d1c8a0a20804fff23da2c1707ac",
-      "rule_id": "AI-036",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "54438de30a1d970b9ac6e9e8c9e0f173b52fb05085ced21d38c6134422bf3344",
-      "rule_id": "AI-036",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "1c3f7e64ac3a7aa0e6d29bf95ecd7c74fa19f8aaac7e89112bc36f345e05a52d",
-      "rule_id": "AI-036",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "987d85d761020153b273fe2e5a3402d1872a9ac98943bcb9fdd98b52e0b3ea33",
-      "rule_id": "AI-036",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "9229b705609e0dafd7affbd44cf9a1bed8e5011482ab565581012ec794817bba",
-      "rule_id": "AI-036",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "3540529cd01cdb1073c6efabe5b591c2469fd2a4d2ab4ba5dc84b1c556673379",
-      "rule_id": "AI-036",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "f91bd6ae5c8bd950d3b617eb46c6d6575f3689d9f4e871a6e94297c1e2868c85",
-      "rule_id": "AI-036",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "c102768627705451cfbbfae00f5d2ad01cba005db3a4680714d2dfaf09696601",
-      "rule_id": "AI-036",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "ff57a2aed4db6032e64cf1eaeb123e63259e85c849366ee5769e69880ab51dd7",
-      "rule_id": "AI-036",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "fda80bb535a4c6ba0213294d45b1bf0266acdf39f302040d4fa509e51b41dce7",
-      "rule_id": "AI-036",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: AI-036 pattern match on Go source code that handles token/key fields",
       "created_at": "2026-03-22T21:41:22.594055Z"
     },
     {
@@ -618,49 +34,9 @@
       "created_at": "2026-03-22T21:41:22.594055Z"
     },
     {
-      "fingerprint": "b6154b09d1abe52b80c1080605cf0684f410f207a38b091bf0c43d7d498aed68",
-      "rule_id": "CONT-001",
-      "file_path": "web/docker/Dockerfile",
-      "severity": "medium",
-      "reason": "False positive: CONT-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "267f7e2d59cb278b062c68a659157e7038352cfc66922b2f307065949f52cd66",
-      "rule_id": "CONT-001",
-      "file_path": "web/docker/Dockerfile",
-      "severity": "medium",
-      "reason": "False positive: CONT-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
       "fingerprint": "955329b40fbec2fae1a9c3ebc2b8a9c8846e99371a929355f2afcb38a82219fa",
       "rule_id": "DATA-001",
       "file_path": "SECURITY.md",
-      "severity": "medium",
-      "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "921f53fc771400f3cdadcb1fa122d3d8b64b362701fc59c5fb97ba07763f0b76",
-      "rule_id": "DATA-001",
-      "file_path": "docs/cgp-specification.md",
-      "severity": "medium",
-      "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "e4bd2edf9243500eac7c5ed7144444430271866d3a21bbdb9b8c1b523a90e6c6",
-      "rule_id": "DATA-001",
-      "file_path": "docs/cgp-specification.md",
-      "severity": "medium",
-      "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "75fecc53c573651696fca5f880dba9ade82d222e9eb569dfd29ceff32cbb4adf",
-      "rule_id": "DATA-001",
-      "file_path": "docs/technical-design.md",
       "severity": "medium",
       "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
       "created_at": "2026-03-22T21:41:22.594055Z"
@@ -738,41 +114,9 @@
       "created_at": "2026-03-22T21:41:22.594055Z"
     },
     {
-      "fingerprint": "2511045a11f4e58296ac0c2600cee31caca6f42bb01bf0ac30818bdece6d7e10",
-      "rule_id": "DATA-001",
-      "file_path": "internal/cli/init.go",
-      "severity": "medium",
-      "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "7fda3134c0692a3a1f17942d910ecfb7c554bfbc26fb7edb5a25164de843fdf7",
-      "rule_id": "DATA-001",
-      "file_path": "internal/cli/init.go",
-      "severity": "medium",
-      "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "6666bf8e7e86737477ededeca5b5f8ad3883bc9acc5a4072222f7128232b24e5",
-      "rule_id": "DATA-001",
-      "file_path": "internal/cli/init.go",
-      "severity": "medium",
-      "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
       "fingerprint": "f0a8463b87f6eb925460bcb37b4e9aaf2981644cec61da15e9de9c997e8ee076",
       "rule_id": "DATA-001",
       "file_path": "internal/cli/templates/builder.go",
-      "severity": "medium",
-      "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "7d5ca895f0c446647144b0d34b83e6619d354d0473efa9632db9304b2c3b2cdb",
-      "rule_id": "DATA-001",
-      "file_path": "internal/config/schema.go",
       "severity": "medium",
       "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
       "created_at": "2026-03-22T21:41:22.594055Z"
@@ -783,54 +127,6 @@
       "file_path": "internal/infrastructure/git/adapter.go",
       "severity": "medium",
       "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "ebcae05f48fb7d893087ee16b2b4148b9758cb72f5e8c582b6b51f5c43a7f676",
-      "rule_id": "DATA-001",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "7769373c365d2f7783b074ecdb9df87e053c54b88a50b227b9365044498f0d12",
-      "rule_id": "DATA-001",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "5dd19f3a6c02f251819120f2681960fef67927bd0b856cb726bba53d3a47666b",
-      "rule_id": "DATA-001",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "fe288a79fd7cee0e1a91014a25d09fc69977eb07cfed900071608fe1b005a321",
-      "rule_id": "DATA-001",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "efd5940d7a95b928c83fd6f998d14aea0a29234267db167dfae0ffdd0497862d",
-      "rule_id": "DATA-001",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: DATA-001 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "988b56cfe7d5051f4c84c66bd7440e771d0af7f83d3e6a69858e68026b13c310",
-      "rule_id": "IAC-018",
-      "file_path": ".github/workflows/ci.yaml",
-      "severity": "low",
-      "reason": "False positive: IAC-018 pattern match on Go source code that handles token/key fields",
       "created_at": "2026-03-22T21:41:22.594055Z"
     },
     {
@@ -922,14 +218,6 @@
       "created_at": "2026-03-22T21:41:22.594055Z"
     },
     {
-      "fingerprint": "4ebe02d81e225b686385180caaa28f8b03788011e4c3cbb8a3d940389780c9eb",
-      "rule_id": "IAC-310",
-      "file_path": ".github/workflows/ci.yaml",
-      "severity": "medium",
-      "reason": "False positive: IAC-310 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
       "fingerprint": "4d28f6aa4af9be8406239a94780ace18e35932949139879edff945cfc4f28470",
       "rule_id": "IAC-314",
       "file_path": ".github/workflows/release.yaml",
@@ -978,38 +266,6 @@
       "created_at": "2026-03-22T21:41:22.594055Z"
     },
     {
-      "fingerprint": "b607ad34ee2c7a423a2dbf0429c34757b12fa1a4149e5b7ee7cccf8d8066fd5b",
-      "rule_id": "SEC-161",
-      "file_path": "internal/infrastructure/ai/anthropic.go",
-      "severity": "medium",
-      "reason": "False positive: SEC-161 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "478f95a94da557998076a70d469a590fc210aa886c0db980f44a67e20da52cb3",
-      "rule_id": "SEC-161",
-      "file_path": "internal/infrastructure/ai/openai.go",
-      "severity": "medium",
-      "reason": "False positive: SEC-161 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "2affc2870eb18e5811abaf0b36df2468345910205f0f6d285f6bdefad084645c",
-      "rule_id": "SEC-161",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: SEC-161 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "ea7d18af99ee41c3b21ad40087a590d40772067f510e51869b52f9c870636e59",
-      "rule_id": "SEC-162",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: SEC-162 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
       "fingerprint": "3e9a95efa24d0d327f5d3b7133a45cdad445ee3c52c4f804d4c4595f1f228c4a",
       "rule_id": "SEC-163",
       "file_path": ".github/workflows/benchmark.yaml",
@@ -1018,41 +274,9 @@
       "created_at": "2026-03-22T21:41:22.594055Z"
     },
     {
-      "fingerprint": "d89f0637d569a1392a01179628154b90444ff0766d5bebed0e7e7a5ec674b54b",
-      "rule_id": "SEC-163",
-      "file_path": ".goreleaser.yaml",
-      "severity": "medium",
-      "reason": "False positive: SEC-163 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "43707232cbb2e8c3f330dc07c73bddb6239f3ce6c965cc6a0c3896364211f177",
-      "rule_id": "SEC-163",
-      "file_path": "internal/cli/init.go",
-      "severity": "medium",
-      "reason": "False positive: SEC-163 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "755bae8e6c147f4a35d38cf0f3f984708018acb8676529265da039e941d9abe6",
-      "rule_id": "SEC-163",
-      "file_path": "internal/cli/init.go",
-      "severity": "medium",
-      "reason": "False positive: SEC-163 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
       "fingerprint": "6b60576d100a938a8df4281fbff164f505d4b5ee35b5e1fc690d9930325765d0",
       "rule_id": "SEC-163",
       "file_path": "internal/cli/notes.go",
-      "severity": "medium",
-      "reason": "False positive: SEC-163 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "adecba896a7c9a1f7887fecb4e1f5fb51239bf142a362007fde4b053c3ff618b",
-      "rule_id": "SEC-163",
-      "file_path": "internal/cli/root.go",
       "severity": "medium",
       "reason": "False positive: SEC-163 pattern match on Go source code that handles token/key fields",
       "created_at": "2026-03-22T21:41:22.594055Z"
@@ -1162,14 +386,6 @@
       "created_at": "2026-03-22T21:41:22.594055Z"
     },
     {
-      "fingerprint": "591cd6fae019a4c5da7e65e4a87602e0e3b0208041588c5d5946f35b7f8e55dd",
-      "rule_id": "SEC-163",
-      "file_path": "internal/container/container.go",
-      "severity": "medium",
-      "reason": "False positive: SEC-163 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
       "fingerprint": "308ab2f9154f379366aa0c984b21a79f386178365081bf2189ddf370e407cb15",
       "rule_id": "SEC-163",
       "file_path": "internal/httpserver/middleware/auth.go",
@@ -1189,54 +405,6 @@
       "fingerprint": "42524c53f70c32c92b19ac9a714f9e9c1c217d9cf9e65d646d046a98b10fde90",
       "rule_id": "SEC-163",
       "file_path": "internal/httpserver/middleware/auth.go",
-      "severity": "medium",
-      "reason": "False positive: SEC-163 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "8243d6438f03ea4636721b6384493d5e1d8e2613758a65e0c043b2a5a8ae6cdd",
-      "rule_id": "SEC-163",
-      "file_path": "internal/infrastructure/ai/anthropic.go",
-      "severity": "medium",
-      "reason": "False positive: SEC-163 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "201af068373ce0bdd6a6fd6261c020b685b942a91f09e6d87c5e8953161b8b6f",
-      "rule_id": "SEC-163",
-      "file_path": "internal/infrastructure/ai/gemini.go",
-      "severity": "medium",
-      "reason": "False positive: SEC-163 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "5a46eb2ffdd5e02f33a6022ca909b7ff6c6da9f7dcb942118e96e7c43e06ec5a",
-      "rule_id": "SEC-163",
-      "file_path": "internal/infrastructure/ai/openai.go",
-      "severity": "medium",
-      "reason": "False positive: SEC-163 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "801f0804a268e95f2007a7ecf2ac6bd0dafd6fea6f40d99ebc7da944431d7686",
-      "rule_id": "SEC-163",
-      "file_path": "internal/infrastructure/ai/openai.go",
-      "severity": "medium",
-      "reason": "False positive: SEC-163 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "99599d865f5e1672cbc4b1e413ca68bfe01205b902dd11dfec49ae7f5dfd5d9d",
-      "rule_id": "SEC-163",
-      "file_path": "internal/mcp/server.go",
-      "severity": "medium",
-      "reason": "False positive: SEC-163 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "ef047cf1db6dc3c040cb8b07610c813e45530bdf642a98c6d828b3e06f61e0b1",
-      "rule_id": "SEC-163",
-      "file_path": "internal/mcp/server.go",
       "severity": "medium",
       "reason": "False positive: SEC-163 pattern match on Go source code that handles token/key fields",
       "created_at": "2026-03-22T21:41:22.594055Z"
@@ -1338,22 +506,6 @@
       "created_at": "2026-03-22T21:41:22.594055Z"
     },
     {
-      "fingerprint": "c6e0b59de93bcd750db34fd936b8c7a2059d8ea0187d040e39349b46a10682eb",
-      "rule_id": "SEC-435",
-      "file_path": "docs/PLUGINS.md",
-      "severity": "high",
-      "reason": "False positive: SEC-435 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "cb9fe57071ce6d9a100d27f5b5f0f1b9889cb17fbd67ebbdbaa80323bd6c5d36",
-      "rule_id": "SEC-435",
-      "file_path": "docs/TROUBLESHOOTING.md",
-      "severity": "high",
-      "reason": "False positive: SEC-435 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
       "fingerprint": "52239e5a2f0ebb8c275c1fedfe2fe35e10e2c64a20cc0825f52821967f0ad23b",
       "rule_id": "SEC-435",
       "file_path": "examples/README.md",
@@ -1367,318 +519,6 @@
       "file_path": "internal/errors/errors.go",
       "severity": "high",
       "reason": "False positive: SEC-436 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "b0762a5b2f5dbd6c5c277943b22e06e0df8ee5eb20fbe9bb804f7f53239e994e",
-      "rule_id": "SEC-437",
-      "file_path": "internal/errors/errors.go",
-      "severity": "high",
-      "reason": "False positive: SEC-437 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "05aac13237167edac03fff659abd77d3fc9834b2003d457058b4d0a751bd3a71",
-      "rule_id": "SEC-437",
-      "file_path": "internal/errors/errors.go",
-      "severity": "high",
-      "reason": "False positive: SEC-437 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "7cce4decfbdb75c4de846cff431f24031f394d822a77bce9193644528d572694",
-      "rule_id": "SEC-437",
-      "file_path": "internal/errors/errors.go",
-      "severity": "high",
-      "reason": "False positive: SEC-437 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "e7edbf7776199dbfc4e7d36c4e2bb2e98e7e05cb4055a3be6c998d7ac434af71",
-      "rule_id": "SEC-545",
-      "file_path": "README.md",
-      "severity": "high",
-      "reason": "False positive: SEC-545 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "b157176f37068bddcbd95908d1a12da6f2aabf6581681e992f2e04aefcc95ddb",
-      "rule_id": "SEC-545",
-      "file_path": "README.md",
-      "severity": "high",
-      "reason": "False positive: SEC-545 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "4e26e9f311ebd6dadf644fa7e7944e5dbae167264d1a2434af861a91165ee2e3",
-      "rule_id": "SEC-545",
-      "file_path": "internal/observability/receiver/webhook.go",
-      "severity": "high",
-      "reason": "False positive: SEC-545 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "43b85e9da1206e35e79a0d174161bcedb0fa8996cfb08b773328765adcf564e4",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "e0d2ec6dc357d3eedb241b0b5c06789fe401772be464847471a3596d40ec7679",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "d57a7cd3ee1f126355cdd9cb33b71f91f041278d4c8201e74f95c19ac45103df",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "da37574846e06a0ebaf97c3d1ca2f09def8bf204e07b54cf2357840d6cb07405",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "7dd4fb7233fdd62176fb67e832dbf653bb972e2352b427b02332e49ea5afbe63",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "cc11ca46a546a5abfd286c63b091990f27cc67d70ded360b80e313af275eeb9a",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "97936f9bbd152f57da45994cf07f9771cf543dc40ecd80deb626aa0e927867ba",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "40ec562178a0debcf97856f2f2e2ee2f22358f1913b5d87dbfa32cd3c5dcc8fb",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "e15384ab7e4bf4071402a7daee7778842e3f6abe259a7c79dfae386428786941",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "7ea1030209e369071892c85f2882523145d9390ce510ad68b5e86d47f9b3269a",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "0c1ccc94349f39fc0e35f7559fb00d18e586a13310ea36159bcca34790c77e65",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "7762b81411480769a0e3ffffb524d7a265ee3d2319c9eef946422d3f646d0b48",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "4ff78db2713cbd0bead1819bd82e42fda0149aca2b7addae641369506d06cbf4",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "5ced579fc5c3be39baa5b256014b0c53e667e2df686d43eeddce3b0a0db01d05",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "8bdbe5edb8def699a2f0175e77b23b49bd5016b65931dfdaf553ac0d32f0d259",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "0af32712bd4a6b69ce283b8e52a37efa2d5db663ce740951fd30860317459ecc",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "d59e9eda52771694ac81bbfbb1d8848e295367529fc8bb0887767f2536326d65",
-      "rule_id": "SEC-569",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "8903ac69fe1660d26f655e679993a081d3cc1ea1891ed87cdada13603aab2929",
-      "rule_id": "SEC-569",
-      "file_path": "internal/container/container.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "a78f8dd4c949bfb2ce61e8f4bf350e673f553fbe72e10d9b6776ad5fdb76f9fe",
-      "rule_id": "SEC-569",
-      "file_path": "internal/container/container.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "6714efcfd172e1c6cc0676097af516680cf602622cd54022dfaccdac07982ed6",
-      "rule_id": "SEC-569",
-      "file_path": "internal/container/container.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "d01edfd65e2863cf395413980b9832d84de78049471acd03b36ef7975c6c0d64",
-      "rule_id": "SEC-569",
-      "file_path": "internal/container/container.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "47c3ead91cbe48184c7290711baafec1fe141a64ef5d8e9833d63b1917ef3842",
-      "rule_id": "SEC-569",
-      "file_path": "internal/container/container.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "a78bc4f364982fc9f9f555dd7bfec926bee0da48148d498f9e182e2c1c0a8a03",
-      "rule_id": "SEC-569",
-      "file_path": "internal/container/container.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "0e7d9d787667d3920d8b698fdf39842f409d5b18f95aa4f1dc7cf0c6272c9fb4",
-      "rule_id": "SEC-569",
-      "file_path": "internal/container/container.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "30e48a81df0fd4d1b44e24b8962a43202b74ae5a200ff019c360bb03032ba617",
-      "rule_id": "SEC-569",
-      "file_path": "internal/container/container.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "52d104136ea116ac3177ba3c463a885f71a36f31b5b9be7a5571b97c43685fd8",
-      "rule_id": "SEC-569",
-      "file_path": "internal/container/container.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "ac78e342ba9ed333e8dc9cd81ca14cc83960ec22e86648d4b0ef4c9e1f7ff9c8",
-      "rule_id": "SEC-569",
-      "file_path": "internal/container/container.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "4e61576cd780ebf9cde0935574cf112f24c781b57455a1e1353dcc639ded535a",
-      "rule_id": "SEC-569",
-      "file_path": "internal/container/container.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "645f915f6ee3a0235d00a8e1e96bbe737cd92205feffe15398002ab8abb84e17",
-      "rule_id": "SEC-569",
-      "file_path": "internal/infrastructure/ai/gemini.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "e6095da513a20bced78a8d137b51ce0dc5c3fa7355a3773542042a7170b5debf",
-      "rule_id": "SEC-569",
-      "file_path": "internal/infrastructure/ai/service.go",
-      "severity": "high",
-      "reason": "False positive: SEC-569 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "d3484bad60fb8c20252cd96de5496cec657029ed7e875cbcb7debdc34a07763e",
-      "rule_id": "SEC-629",
-      "file_path": "internal/cli/policy.go",
-      "severity": "high",
-      "reason": "False positive: SEC-629 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "545619d60f64273f46a18c495218f636d3850d87bef1dc251dff4c209d9ee0ae",
-      "rule_id": "SEC-629",
-      "file_path": "internal/cli/policy.go",
-      "severity": "high",
-      "reason": "False positive: SEC-629 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "062d24017dcdb3f2be755c733aef8cab6b59b513b654348ea786dcff250b6034",
-      "rule_id": "SEC-652",
-      "file_path": "docs/cgp-specification.md",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
       "created_at": "2026-03-22T21:41:22.594055Z"
     },
     {
@@ -2066,470 +906,6 @@
       "created_at": "2026-03-22T21:41:22.594055Z"
     },
     {
-      "fingerprint": "e813a9ff97398a7a4d190dac92afe2cf047ef9be9fb198347f490bb21b958027",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "263992043635dd46c5cf8a0c90f707a5aba8f8853dfd898dc89367ba86dfe049",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "9f3418b481df18857167f86122c0c112416c262cce0407c9064310f5010a68bf",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "49f4a30ca852ee62ac9179f5d56d55a67510f42e95badc9496093588885f8c54",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "a9ec1ced7d39b4aeec959c4a20ebbe0a1dd4b7f31b2bd21db1c1824a48ea638b",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "206a543c11d0a86b23a7b03959156608d7ae739c079b2754c7cf028d8a5c5470",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "dad95767127077bf601a301f9c634f908ce1d285a7f8fc0d0e043801c8dda4d0",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "49776ef3f3cc1b194ee3c33fd8b716470645a65321a42e8de84ce67f3111c0c2",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "533a1a0ba404b633f439543170ac4989b25d0348ae410ffca4a41b51f9240cbb",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "5f8af8e6f921ee8e182b5255b607353fca338f5b013cba7c0601c14e3166157b",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "63d7957b2fcee9bf3731fbca75ee291c468a68a482751de354e52df37074f3a0",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "edc1f14d44a311ea9350d5931ff8479b83dfa852621e5a7c38ab8b2a28ccc132",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "e023d61f8e84150e11631eba879c7841234b141d8d4be46fc2601386d1e4576f",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "bc66c17721f98394d1f91c2a8902f659784a893f19ab0eda4045ec2ab9115fc1",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "d84640feb48d31ae8eb6a75a963c147a20caa43b2f9ffae98deee72d6f19bae0",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "ab909771cbd3e4891102e7656a88f20319fb259bbaa3563c7f8e858b3b66fd2a",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "2ac5d36fb81198c26c93a822768f27d0aa81d9e7a60f0c3ab72bbb9f55620252",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "7394e6daf86f709bd1cd4bcd30fe93211ef7a43890603ce0ab797d71dce43051",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "e10ce8cf45845ccec8735c58f8b0ffd44570b55864394d5b0c81f6c0a2ddfbef",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "da1a5cc2a6830322f6c1cd6b425958b760c5b02445b8a6709e93c6ad97f47b42",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "e03e5d7ea03aca090f8d00da6e30a9ffb599e832bf00fe0537e7ee7a4766db61",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "dba912eaad18e4c4d5b59546bb90b425e50f2e8e2e1c7281c43d32619ad60be7",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "dc3b089b3679c888dbf31c2be0b1c35615477ee0a78c09dad60c86ecf6057ff2",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "852ac950c03f41d1c7c0242a8d27ae5fc6ae2df74e81166cf1e49404fca65187",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "13730d5a8584abaa1a75d5bfbddfd9770bb325c5d7188540d9ca76b6ccd14c8c",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "676818a4aee71ce9339d0f38c50d564a952cf263d9571030eb74879aec8e9d43",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "17550b62095fe5c1ceb1033cf88c96c302708413811faafea12f665cba7a91c8",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "c1bbc24321751b23cb393f57a2515f9792fd7e99dfe4dee2804bfdc3ae103855",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "9957139dc72369a3cef139fd08fedc6241222d93bb5ba251244c3f2a3c74558e",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "a89ece48ebf4a896d7e834d69ac33e8db718ab18a5ed7f47c3f5c7a475e078fb",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "7cb391cd5b0d1311965be4e78f8b8234781a4b0f9f30adab51fa7d8a1c3aa808",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "e85ef3c3e6b5a3dd7e46a67b4d1e199e38ea18321e296cc9129fe9f5fb74bc89",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "f693a1a39f02f35caef63ae27c70c8ea7084146669af3fee5b58e3db35ef7435",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "be2a58c56f37263acba84f5d03c5e5cbfba3cf1e5144cb2b028d4df7b2670ddf",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "c25db93d9aa405d645acc0d8184fbdc79aa91a7b3952f214360086606bc4d8ba",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "6468d4ac86d6bce4faae19746885635ecb68ec9595931dfd2ec0bfaf1f6d16d7",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "64fa7e3f72df6fbb21cfc62486d88d5a1d6ce9aa3b5e809eac92c43129a73ce8",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "f177fa75a984ac782bdb0abfe2112779fef3f941ab3abdc03aecb5d6f449f402",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "914bec4944becef5a7a0fd71fd9e1c2604f043a8b54649af9aef19481f33d81f",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "f2e8b4cc1e964097bcb34f960addba44910e8dc44fd1b14c1bafc22766cf1d5a",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "227f38c43666c37e47d0e20f1cdcd9ffe9a9341df3537666a174da41ab3beee7",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "c901f82d322562ded37d9df23aeb5f7d9d4eb7f96fce1cb9d39de9198541d62d",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "d544ea8ce32267f93d2c7305690998dfe735e592d1a1034b206b9bcffdcd2878",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "eb6b57fd666c4e4259ad8cf7110ad5712bd567509475d5f64e573cfdf70a79f2",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "2cd389120c2ca673d4df0f73e0678784172b2369910046d68aa0872b764b2ed7",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "e37091c4cb1ca9e5f20f11807f10a496a76dbf627abb92467e01292fa10d4726",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "83f98d2cdf7cafcbaf05cbb4634ed9afc36bd57bd7bbb458650ca1a5629179c3",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "1fd327b886387c230641f12e3ecc35fd54265be3233889f23b69cbe1334f4409",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "ef99f17d1d59e04e213d6051a7a388ffb283097068a1b48e8f9462b71b9bdb05",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "e1617c22865eec1312da7567a6785d0e7331933a8f93187627a8f138a1955c26",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "c02e92baf21a019bf6f1e1b1f84de9a158ca896014686e2f0ee37487404320c8",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "787a720532c66fa42293dadd758c21dd9ea5f3174c9796fdb1dacbdb5d99cfa0",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "9bfa47110f7927187ce1c58a38fb5153fa689c89329b22ec9cf4896c171b4838",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "f3edf519b9631611194a5be40b9dbfa247d84ea13230bd9062b3bccd0f92b0fa",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "cb9018cd98e57594b9d9915444219e9d3c987492afac6299f83c5d7bd7f22f83",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "a4106e2a31c2403427591ee96acbd3f9ea0e45bdc324de0e1c59772ff627bbd0",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "bf860b2b1b2d9e7946ed9657eb243fd75d5481c01b114c1b1a4aae658c1b526d",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "7f871bf242fef1f6f8567064bed4fe34d3e44641a9afc1a7b24fbe87ec3cf7ef",
-      "rule_id": "SEC-652",
-      "file_path": "internal/cli/approve.go",
-      "severity": "high",
-      "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
       "fingerprint": "8416efa2a2e0024f482e3cd2c73a6d0b0d7207bfc68dcc6f45022f03cf2903cf",
       "rule_id": "SEC-652",
       "file_path": "internal/security/masker.go",
@@ -2567,22 +943,6 @@
       "file_path": "internal/security/masker.go",
       "severity": "high",
       "reason": "False positive: SEC-652 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "f245f28243dbe8a79b4608dabf2eee059e72736f9e11e7ebb53e47db29151a2b",
-      "rule_id": "SEC-659",
-      "file_path": "internal/cli/policy.go",
-      "severity": "high",
-      "reason": "False positive: SEC-659 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
-      "fingerprint": "49d40df23afc190a049ba94d886b4ac050ffbd591bf43e0f3bb088db87d9a89f",
-      "rule_id": "SEC-659",
-      "file_path": "internal/cli/policy.go",
-      "severity": "high",
-      "reason": "False positive: SEC-659 pattern match on Go source code that handles token/key fields",
       "created_at": "2026-03-22T21:41:22.594055Z"
     },
     {
@@ -2658,20 +1018,1125 @@
       "created_at": "2026-03-22T21:41:22.594055Z"
     },
     {
-      "fingerprint": "9e5c58af832f713ab3d020c1d07701f4cf8eb7c98000cc57ffdb2fb424fde50b",
-      "rule_id": "SEC-792",
-      "file_path": "internal/config/schema.go",
-      "severity": "high",
-      "reason": "False positive: SEC-792 pattern match on Go source code that handles token/key fields",
-      "created_at": "2026-03-22T21:41:22.594055Z"
-    },
-    {
       "fingerprint": "aae857469ca8edff240ba7e2b69c5d0b70ce41882eaf9cda319c300c95b57743",
       "rule_id": "SEC-909",
       "file_path": ".github/workflows/docker.yaml",
       "severity": "high",
       "reason": "False positive: SEC-909 pattern match on Go source code that handles token/key fields",
       "created_at": "2026-03-22T21:41:22.594055Z"
+    },
+    {
+      "fingerprint": "11620ae9e1cf8d06d1872923c512c44bf77c93861645abf6b8310ca9ef19d866",
+      "rule_id": "AI-006",
+      "file_path": "internal/cli/eval.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "35d641d28c1b0f959f4f7a2198eb05884476e0f02ece7c28e1b992249c48fe1c",
+      "rule_id": "AI-006",
+      "file_path": "internal/infrastructure/ai/evals/judge_llm.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "17c6cbee3222b18085a9d9007363958bb9219bc71c9ff0e3537e3295113047fa",
+      "rule_id": "AI-007",
+      "file_path": "internal/cli/eval.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "7ee3efb45c3c12d1008b7b76fa009ea404cf7db2a14596a7f467170f97d2fead",
+      "rule_id": "AI-007",
+      "file_path": "internal/cli/init.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "85892c34ca24d85ca79a4e02f6e3497bb8a8d2036f2f7ab3d30120c01e4bbd30",
+      "rule_id": "AI-008",
+      "file_path": "internal/config/schema.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "5e06272322c5e4049eb8b871075c2c91ee90fd2897c670961317fb47db1d620a",
+      "rule_id": "AI-036",
+      "file_path": "internal/config/schema.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "21b75f469cc96eda81212f543f273ccfd46570514a2b14f12a9858e5b407794f",
+      "rule_id": "DATA-001",
+      "file_path": "internal/cli/init.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "0d12c4576eaddc26d03ffe6ebdaf122a47ceead74cac85acdcfa21d9ada595d5",
+      "rule_id": "DATA-001",
+      "file_path": "internal/cli/init.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "b4b7caabea86987c57110b83cec8e09b5b311423697811024b2ea40f58dadf37",
+      "rule_id": "DATA-001",
+      "file_path": "internal/cli/init.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "ce743788092c06a7522fc4501453dfb32b4bd1ac34fea4518321a0a8d689a1ba",
+      "rule_id": "DATA-001",
+      "file_path": "internal/config/schema.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "20aa3de3f96b3f3e7e4da4240bdf9af254052e8d47427274871044a0934e39a6",
+      "rule_id": "DATA-001",
+      "file_path": "internal/mcp/server.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "c181f4534a36871da6ec7fa13e8bcb4c928f304c053fa4de4829954287d03981",
+      "rule_id": "DATA-001",
+      "file_path": "internal/mcp/server.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "d5e34ae7eeb6df5010195e0df76cbcfbed5ed41c111b54cc764b81fed1d84ca8",
+      "rule_id": "DATA-001",
+      "file_path": "internal/mcp/server.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "932434964325f318d551fb0ba576a3caf9b3a0ab37c1c17f76b0bb964624ac31",
+      "rule_id": "DATA-001",
+      "file_path": "internal/mcp/server.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "0ff0feab32a34e83e0c21dcf9a218e21f60afded6685256597e5a7b4199fd0f9",
+      "rule_id": "DATA-001",
+      "file_path": "internal/mcp/server.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "9bfc70dfd040e5344c852243dd4c633eb1551ce177c257fd0556e4d6486b6f93",
+      "rule_id": "IAC-018",
+      "file_path": ".github/workflows/ci.yaml",
+      "severity": "low",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "9c4ca5409260ff45075ea5e5204014de866485d3f6b010b6348adb08092fb53e",
+      "rule_id": "IAC-231",
+      "file_path": "docker-compose.demo.yml",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "ab35a504ac25eae4fe8ae8b2dd32e2256830e2662d2a5365c146b1b82556f925",
+      "rule_id": "IAC-231",
+      "file_path": "docker-compose.demo.yml",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "4ad383bd4a9f596639b5ec4276063a0083ff91e54ef841fb3fa1f5b38cc7cfb6",
+      "rule_id": "IAC-309",
+      "file_path": ".github/workflows/ai-eval.yaml",
+      "severity": "low",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "b0da03114a8d12ceaa4b0d939d67f5569706d6b0db4dfa0c6de1ac2b25197891",
+      "rule_id": "IAC-309",
+      "file_path": ".github/workflows/web-a11y.yaml",
+      "severity": "low",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "456f274368005709424bbbf353182ebe35ef7a74a97082de5ed8950d7e154b48",
+      "rule_id": "IAC-310",
+      "file_path": ".github/workflows/ci.yaml",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "b2084c07d038f4b77c940fc463d99107473f24ca89f791f0950847b703c9476e",
+      "rule_id": "SEC-161",
+      "file_path": "internal/infrastructure/ai/anthropic.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "6a6b5257a037a31ec097425dea62753ddcb9c42a8aef7f6d8cae857d52076e63",
+      "rule_id": "SEC-161",
+      "file_path": "internal/infrastructure/ai/openai.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "abb4c960ab4e3a28c24406a913e4830b0de3538318c034a18b81d02a254d8f5b",
+      "rule_id": "SEC-161",
+      "file_path": "internal/mcp/server.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "f88e37ad4c14dd35c6eb752059f1793f5b7f32b9e69b8c4fe6fb5ad4f572cd34",
+      "rule_id": "SEC-162",
+      "file_path": "internal/mcp/server.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "6593d8a39cc0fb92a4caa078535ba5dd95782930fde66537444df9273ca02726",
+      "rule_id": "SEC-163",
+      "file_path": ".github/workflows/ai-eval.yaml",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "ca910da313605a6e6eb2f4c478f546fb5aeaa4f90daa5da8ecf82cb7388f0aba",
+      "rule_id": "SEC-163",
+      "file_path": "internal/cli/init.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "c485910583f024e2a7a2309d48db8ddac9a9b58c4a161875e15189948998dab9",
+      "rule_id": "SEC-163",
+      "file_path": "internal/cli/init.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "92be319fbe8aedf6df810cf779ad18c6e6566d04dcebb4c16f2e3bbfcad273bd",
+      "rule_id": "SEC-163",
+      "file_path": "internal/cli/integrations.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "cf3e27a908b0b8ca451aa754a2b0ec5b22a24d98c67d1304c8483fdf385dd5bc",
+      "rule_id": "SEC-163",
+      "file_path": "internal/cli/integrations.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "678e6fa8afaa6e63ecdddc9dcaced25c15f326f6531b1c0b577e951fada0693a",
+      "rule_id": "SEC-163",
+      "file_path": "internal/cli/integrations.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "3b582bba2c6a21eace46a912b8f07c4039ed749f4856a67c1b1b627ae98a42b5",
+      "rule_id": "SEC-163",
+      "file_path": "internal/cli/integrations.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "9774d516c6b9c9a163aa4db22205733984be711abcf1c35c5c26897d25581e7a",
+      "rule_id": "SEC-163",
+      "file_path": "internal/cli/root.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "291f3bafa5c46f3e5141c2e166cdddae6f48fff38c752deb18488afe68cfb0bd",
+      "rule_id": "SEC-163",
+      "file_path": "internal/container/container.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "1bcac04d7b83ee9d28340113038cce924b75530e78ac2840de734f4ae20cc91f",
+      "rule_id": "SEC-163",
+      "file_path": "internal/infrastructure/ai/anthropic.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "823b10ec8e722aef9a6ed60adfbfd47ea96fa16824b6f7153b6beb3deab4b922",
+      "rule_id": "SEC-163",
+      "file_path": "internal/infrastructure/ai/gemini.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "1bc5e597cf4bc9d35e872ec764fddbeb047b0f5e18ff84b5dae55f0e81d88d2b",
+      "rule_id": "SEC-163",
+      "file_path": "internal/infrastructure/ai/openai.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "c375ea116f945ef2d691038d2e674ffb571c64510fa1cfbaa8e04c236d326553",
+      "rule_id": "SEC-163",
+      "file_path": "internal/infrastructure/ai/openai.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "0ba60433f59e3780dd899b3d7c3d0581361270fa00c2f4cfb78a06219aef1e97",
+      "rule_id": "SEC-163",
+      "file_path": "internal/integrations/drata/client.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "f94f9d0736c343b3b2f355f761dd54929b9557c731181a25f569b83bf551754f",
+      "rule_id": "SEC-163",
+      "file_path": "internal/integrations/vanta/client.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "150129c33e973d62a2ce1f88da4c2561d77019efc0c0024e2caacf6fb9dc41b6",
+      "rule_id": "SEC-163",
+      "file_path": "internal/mcp/adapters.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "c117536a898178265f8534551b95fe4d99adb16a8f9b804dc973766ccff8ce9e",
+      "rule_id": "SEC-163",
+      "file_path": "internal/mcp/server.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "ea2c90e7c0a8831654a03e515217a4c6bb36a087a8202a694572b4c67d19e094",
+      "rule_id": "SEC-163",
+      "file_path": "internal/mcp/server.go",
+      "severity": "medium",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "2589c43084d4f8993a71fc274d92fc8b282e26ca3cff0dd6c77af6e11ea963bc",
+      "rule_id": "SEC-569",
+      "file_path": "internal/compliance/annex_iv.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "c16d28fbcfcae93467a819cdf8e32027c2e6e9c4fb75fcf7f4f846c19754e398",
+      "rule_id": "SEC-569",
+      "file_path": "internal/compliance/annex_iv.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "5bc04b14bd7cd497a38283464411e7dd7dcd9ff189b91ec21995c109bddfc570",
+      "rule_id": "SEC-569",
+      "file_path": "internal/compliance/annex_iv.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "8605c09c06e3ae787c84fc1f6079d5015dc6332eed9b2234176d5e322ad0360e",
+      "rule_id": "SEC-569",
+      "file_path": "internal/compliance/annex_iv.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "44bdc9d207f6a62be3bc207aede736e4db95d52bb6170ef004c94f1e69ace336",
+      "rule_id": "SEC-569",
+      "file_path": "internal/compliance/annex_iv.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "31b42bb83309b020a429dc7605e14148318f5e62021d860b07d8c4ab97ad6b3e",
+      "rule_id": "SEC-569",
+      "file_path": "internal/compliance/annex_iv.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "f3b0cd523f4d150d12ddd25aedc70fd1d820499492889721908eb75d3c05d975",
+      "rule_id": "SEC-569",
+      "file_path": "internal/compliance/annex_iv.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "9c4222e271f7887257481d06b02545661fde5d82458e33883de1dc0fe14fa215",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "a23a3f84a2c838982b12f13c1598c635a1870c7e3bb2eed04c40829d994ad684",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "4a3107b78dd82333372f03b76168d5661f399075d5e9c4b74ca849dbaede090d",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "eb2b5cab2262942baa44504b52e44501756cebaa23af98a6341279b03d3e10a7",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "6c7e05cdf72e41fce70e685f217217dba219e33742a0ebab772b0e5b6f05ba1e",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "783c295707254021e6ef2d4d4d36e6e4c45b4c0ec3e52f15e8a4e9463d68d58d",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "b2f6e50eb0a7ce5b1a77a59be86218a3f26da4b97f5a4932b06073ff2ace5ff9",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "aec976cd35e19963fdd145052f9037eb6c1945450aa9ee8c78daf43740495d8a",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "b324b56d7dfdcbda6d02aa098f6592d3d32ad2f62de0e9c183b061667c375b0e",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "5c4a776fa2e627ba4d69e56649349670ae7724290b1fd441c87e180a87a1c597",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "e4ff7dc363f17938fe1d40dd3c68e6454b8bffae6d8a6d3f75c32384690882c4",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "771c808d0e149af133a8c014ad4554762cf622fbf077bb9d728578922d6724be",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "8ce23364aa0a995a317722fc479e761729ba674ffd064a144d5024622b643e56",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "b5701acf57b2bc9587fa5b4a1a27a7ad2af621f7b97b5e9b5b75e62ffdcce126",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "4d9268f8e9ff309881456e1d51f630e726dc7543043fca25af7a0088888ee7f9",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "234e0b7b4aa43ab7499b12262f04e37b25b3c3f1dac6b92fdfc4d4cea214c784",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "f10770c1d82a424932a0b628f7b797767f6aa96b5887ff007867c702b4c20a27",
+      "rule_id": "SEC-569",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "319666922783d368361d9d0a153db039704f9b62f7a46271fc1b84fe6df717c1",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/container.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "8086af6b752902d9762b49796e9bfcb72ea658a1458f47c91aebf315a51497be",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/container.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "98ff44d3d67032e1adb4bdd62a73345532970959fdf7c673480cae33a02eb3ce",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/container.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "00d3036e8984c8c2c321d6af2f6701e2cd71ae40101c052220f6a0086b254997",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/container.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "7e888058c25df17a40471c881d1c6ef40544a404177eea4ebbd077b00ea3791c",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/container.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "11518a8fa070c68275f6d5ad01a554b3207ecb661887a43721e41a33c463785e",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/container.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "96e616ddb650950952bbaf56e9259e7a6d8fcf3242f0f1addcbc625c90da5fbd",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/container.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "2cddcded7b2192fb894cc31e26bb4ee5b061927011764aa2a153b6eff29c6579",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/container.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "3e75ede564d71dd42b1a2e6b84e91588cba86a3d2530259918e3e477ecf717f1",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/container.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "82593b4bd695c622587ac63760e593068abd8f2b22d29859c1510470edd37c44",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/container.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "498058f7e22b71893edb511a8291e1c02221a4a275df28dbc6d8ce3878a5aa66",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/container.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "3e5a0439a2f535e27767cc896b96210e7754508fc0d63fa3e74d78bb1b7e3a8d",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/container.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "f1dedd49fbbafb22b40cb809bf221cb423d74dff7443ac8619a89af893fd6505",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/container.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "3faf0963c4a1e7bbc47293a22e7858b7c3e19d08b76152c275a8336d5559fe63",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/container.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "77a95d8544f7b6133654690cfb77864563eb00925bd06762fb5786b70df29f1c",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/port_adapters.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "3e6f288ad9ffc642f7a37202f87874904c7e62019e2e3b4220eb81341a5079ab",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/port_adapters.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "11a1d8a54b8b8c77459eaae2c249e9b6079b181acf5395b718450b87c4756e56",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/port_adapters.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "2f3dcd201c14c8bf7b24281540dbf9947ccba0dd1d211a730f29135673c47c70",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/port_adapters.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "bc96e24c22678f6ca7d0719819bbae243c905c511b5f65df52bc6b4dc7be46d4",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/port_adapters.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "4ce38c0545f2ef0f01a4fdd6bdb38b0232016f340527c3fd4c6037c992c08db0",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/port_adapters.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "96d27fa2dcf8fc9acaa9c6e11f76b1e88a4d3edb54f09b86dc82e9c4bb977cb3",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/port_adapters.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "feae25d4b4ce1baaa1c27bf4e2860f8978d83e514798530d0587c94ca8829310",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/port_adapters.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "cda5abc0f003589277673e70f632da6ad6e3fd0ff42723510633a3262cd72abc",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/port_adapters.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "be86f6ea11d4c25786e7f3cc844ca56de55d24f2fdc6356471149ce85c403fe5",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/port_adapters.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "40a1e89f6e7ae18cf4b4612fe30cc7380bdb368eb9e22b1d5f8e7608524d4efd",
+      "rule_id": "SEC-569",
+      "file_path": "internal/container/port_adapters.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "3bb8105651ef7b2f10882b0e819b35aa23a68e748e76018cbd785ef41636babc",
+      "rule_id": "SEC-569",
+      "file_path": "internal/infrastructure/ai/gemini.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "e825ddd938d208009e2a5858b421cd7462d48d2acf235e20818be92d02d8a671",
+      "rule_id": "SEC-569",
+      "file_path": "internal/infrastructure/ai/schemas/schemas.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "8e72a6aea4802a4211065428d05cbca9428573e0be24486462e94eee19ac3cd9",
+      "rule_id": "SEC-569",
+      "file_path": "internal/infrastructure/ai/schemas/schemas.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "916ba0a2c2a245bcb45fa93a0112c7d4c78eba89f1b922d6b7cc240f2eed8813",
+      "rule_id": "SEC-569",
+      "file_path": "internal/infrastructure/ai/schemas/schemas.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "cbbc70a127ddd43c967197f05436378dc5e2564f455ec7b1972f7d60498680da",
+      "rule_id": "SEC-569",
+      "file_path": "internal/infrastructure/ai/service.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "5aefb2c58cf4fb4f61bc82f7b9da878efa0f1477d51d4d31961e3b68ef39b2ad",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "b8ace8cf3933e3e037d167bbe236a78155e2adecddd05a458536f01330af0879",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "6f4bb5b1d9812a9683bdef6f217b54bf00fc402221deb926387dec56a8159646",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "1a97623bb3464864435eb4d5435f56e0797654d5b9b0d49115ab3a5a472a6d16",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "b89f47a100b488af4e32e48313ca9606544df9ab0619696a5704fc24dd2bf868",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "dcc0dd84296e78ab224985ec35fa60d0fc00cdcf43282f10f9dd66c4063d2307",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "d07a01c57038e41ef2a3be4b493b1c05aa2c799d79588ae131ba7db91a5c710d",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "0b984855308d5aedd6967d9605607d005cde28afa73f8f37b50bd61d1479fd27",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "fe56eb51dac813efaf13e903ca94dedb2a895b3c8393aa3d234fea07b3f15957",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "ac5b16e1164cea5422bdbbb9bca9c915e71e55cf8e1056c1d6a36c07777d06cb",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "1dd58be1e2fcfddf7cea49208f947b9fa537e1686115607755c2afea4f93801f",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "789c4d380c422a949d172e4cc1428ebac36c029068741868b84f73c4edddf2c0",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "3d00ee6bf361cb2679ad1d0668363bb8ca2ea3a1fcbe4783adc69d95d75ba800",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "a7c73d6b62b1d546d3fc4f4716a1a1d57fcefe93e0826242c746a11ac12afbc9",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "697cde862fb53ef4de2b284c0c8574facde064cfbfc067e238bd3b880de43ce4",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "b4dfc7a62c3ec5b4bfa612d80a2478a2cee95f65f52da87d75766d398a629ac4",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "739580ea0ba7f65a049036a97e69df687a42976ec4418d1f6f3914395e72128b",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "02f80e071448cdcb3c36046d95ed12168faa35ac7708d845d4f20aa9d8ac9eb5",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "a8fc1084633f2ccd9bb4c26c41ac7a8ea36a26783456b94782fba105f2f736c3",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "af6b9ba6b73ac6fdcdbd77eed3abcafa0071bbd5bedea8a4b83aa80c6718abc7",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "63d8c56b4b845069abe89008d2ad1cd255eb438a5feda7ff2ad6c10b36c8e4d2",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "206e8f9ba76f4a5d5a756587412a398d7fc403e721c80acdaa2968453a1d8d59",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "a1aaf4dff2b113830c5a7af1f816fab2493e2d82ece318b6e66a0f2eb9465495",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "7720fa0ab88f50efa8d6a00d09db346e4e50315347aa460fd4c3f0f33a19bdb7",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "8bb1dd15c4c91a10893d97dd0853a99c08345b74aaa3fbbee598f9c6b8daa7aa",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "00eec2e2afeb57df59193188aa791fc20951093f945be006f8307d6d277e4040",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "b0b2a72ff4f1cd5d956704a629d237d7ea2d87414dec0b8bd4c18cc7f36a2d11",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "01a3fbb871e4b8ac094206b04563271d7a477867d9d0539d6d9a1d2e259abf39",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "8ec35ee3b80df9021b71001953386378fbcec393ecb5f255ebe4fd85c2e36c31",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "b88b334fe25c49633c1320f95f76b48e4e21205719ab4573eb8ad64d154738f9",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "bdda54cc9dc7d8599aa28cf91450eff0b2dbe425725aaeace8f328826a38de7d",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "71de3d078dd2ef10f677da2f7b76cc29e859e7a20e270d38499680a89dfeb24b",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "74a600cf2654df83e9b805157f7f649a8df328401c1c2eead7ecb43233745f88",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "b8a73ca227f516a36e6dd0b8ea6cc55b5c5021e8d8c6b3b18817e22676bdf1b3",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "3ed59eeddb938f8729caf33c33398c2c0003b4b0a4b054b6d944c65e5febaefe",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "6463e4d2c57a9c49f6fefccf1a2f07319974721b30a98bf6639741ec7602ea3f",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "d0aa482595fba6b7efad9d2b3bc28a9122656f82452ac5d80089e25b1b2d546b",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "5ce88d5a5e7e8b0e873037b3afd850c6637dbd9b3f453b52c2fb90c60ae14bc5",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "6b1fba03a301bcf93c144f57dcec1196b7a5efbd1f602a6014e78f34966fe8ca",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "d1b87bdddc0317f8a8a2f1580a265d9d32b1def1e4c5d2dd444ba8d794d08b0a",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "89067ec26185f2694af10cd7d78c0fb03319f3ce6b02158374e088bfee7ab676",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "906d49da023cebb677f2571d467844e303f44adadb22a514c27171662cdd3487",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "4f6082bff52555071d5249657c0f1a0d18e94058dc796925b06208dcbcc33e99",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "d8fc68bdfb594cb762c1ccb9775b66e6269e3cd6ec2a78a59eb483804354d21b",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "2360077c422cae19fbb377cb1275bed0cb81b9de99dda059b182db343a8c5a20",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "2f834d87ee21310e3b789deba14973c4f304e560bb27deb83467b3de2a1bac04",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "fd4f0c8047784b92e7f6c52de4c6efdd883b606eb533dcf8d38339b7cfb74374",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "019c46645b43433e02876bf97f033d94ce33d22c0cc9c4835a92ab6e947a5fa0",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "f4f2e277760afbde65c53a6006c5b11f80a1323dae16d1864e92c23fe9eb0a92",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "9be1a0f284a4cd1e53af2ad5c54effea16cfa3f922d3c82a5b4069e4108ea8b3",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "a607dbe30b022bc1e30c0e98a40725e804e95af3e954f01dbb4c2a6be20cde48",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "dc1b8af62e64d2db6b0d63ac2c8386e45b6d0de16c1f77e7b0e022b3192b7d30",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "14e3969761f02208c734e048039fece4dba6f2362323ec5ed262f912a9867cc6",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "42fff91e04262bb4e9ebcb146b335a2e0ca3877e55a50fbc70f99c46174efec1",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "7781aeb35c0b4f8946b74b96f6451add74caa5d970ad52f61ffba16d7001b6bd",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "d55af42f8c3bcebaf9f09851f441c643b2d89dd4e859a8635aec3e57015c32cc",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "7bcf090720a4d3c3cccf992bab48a5efc186744a6312d87979c64aee08ac3f4c",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "94a23d6935934a7d5b1150e5009cd3c6444cd025c227da5b818a27e75c49282d",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "2bd378033a32f87517cdc0af91fc3479c74aa45d106ffeaae87d8b365f742080",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "2708c926520db4d6d3946d19ba85812fa76dc8e9354e839f06e60928b197a378",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "9dc006826a34f7d1a02b31dc35a443bb19e8bc6dc1761eeddfb0d3b5e884a167",
+      "rule_id": "SEC-652",
+      "file_path": "internal/cli/approve.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
+    },
+    {
+      "fingerprint": "6fc9b6dea82ebb1a1234d65bec0df2b86171996fd581b46579fccb7c4c66cfb5",
+      "rule_id": "SEC-792",
+      "file_path": "internal/config/schema.go",
+      "severity": "high",
+      "created_at": "2026-06-11T05:55:55.764244Z"
     }
   ]
 }

--- a/.noxignore
+++ b/.noxignore
@@ -3,6 +3,11 @@ internal/mcp/dist/
 app/
 web/
 
+# Scanner output generated earlier in the same CI job — scanning it
+# re-reports every vulnerability description as a fresh secret finding
+govulncheck-results.json
+findings.json
+
 # Lock files (dependency hashes, not source code)
 go.sum
 

--- a/internal/architecture/layering_test.go
+++ b/internal/architecture/layering_test.go
@@ -24,9 +24,9 @@ import (
 // Adding a new entry requires reviewer approval — that's the whole point.
 // Removing an entry tightens the architecture; preferred direction.
 var allowedDirectInfrastructureImports = map[string]string{
-	"github.com/relicta-tech/relicta/internal/infrastructure/ai":                     "AI provider abstraction is a leaf concern; CLI selects + injects providers directly",
-	"github.com/relicta-tech/relicta/internal/infrastructure/git":                    "Git access is a leaf concern; CLI uses go-git directly via this adapter",
-	"github.com/relicta-tech/relicta/internal/infrastructure/persistence/postgres":   "DB migration CLI commands operate on the adapter directly",
+	"github.com/relicta-tech/relicta/internal/infrastructure/ai":                   "AI provider abstraction is a leaf concern; CLI selects + injects providers directly",
+	"github.com/relicta-tech/relicta/internal/infrastructure/git":                  "Git access is a leaf concern; CLI uses go-git directly via this adapter",
+	"github.com/relicta-tech/relicta/internal/infrastructure/persistence/postgres": "DB migration CLI commands operate on the adapter directly",
 }
 
 // TestCLIDoesNotImportInfrastructureDirectly is FF#1 — the hexagonal

--- a/internal/architecture/layering_test.go
+++ b/internal/architecture/layering_test.go
@@ -25,6 +25,7 @@ import (
 // Removing an entry tightens the architecture; preferred direction.
 var allowedDirectInfrastructureImports = map[string]string{
 	"github.com/relicta-tech/relicta/internal/infrastructure/ai":                   "AI provider abstraction is a leaf concern; CLI selects + injects providers directly",
+	"github.com/relicta-tech/relicta/internal/infrastructure/ai/evals":             "eval harness is a dev/CI tool the eval command drives directly; not part of the release flow",
 	"github.com/relicta-tech/relicta/internal/infrastructure/git":                  "Git access is a leaf concern; CLI uses go-git directly via this adapter",
 	"github.com/relicta-tech/relicta/internal/infrastructure/persistence/postgres": "DB migration CLI commands operate on the adapter directly",
 }

--- a/internal/cgp/policy/actor_budget.go
+++ b/internal/cgp/policy/actor_budget.go
@@ -202,9 +202,9 @@ type Violation struct {
 
 // Decision is the outcome of evaluating a budget against an operation.
 type Decision struct {
-	Allowed    bool        `json:"allowed"`
+	Allowed    bool         `json:"allowed"`
 	Budget     *ActorBudget `json:"budget,omitempty"`
-	Violations []Violation `json:"violations,omitempty"`
+	Violations []Violation  `json:"violations,omitempty"`
 }
 
 // ErrNoBudget indicates Evaluate was called with a nil budget — the caller

--- a/internal/cli/eval_test.go
+++ b/internal/cli/eval_test.go
@@ -53,8 +53,8 @@ func TestEvalNoopService_NonEmpty(t *testing.T) {
 
 func TestTruncate(t *testing.T) {
 	cases := map[string]string{
-		"short":             "short",
-		"   spaced   ":      "spaced",
+		"short":        "short",
+		"   spaced   ": "spaced",
 	}
 	for in, want := range cases {
 		if got := truncate(in, 100); got != want {

--- a/internal/cli/integrations.go
+++ b/internal/cli/integrations.go
@@ -110,7 +110,7 @@ func runVantaPush(cmd *cobra.Command, args []string) error {
 		token = os.Getenv("VANTA_API_TOKEN")
 	}
 	if token == "" && !vantaDryRun {
-		return errors.New("Vanta API token required: pass --token or set VANTA_API_TOKEN")
+		return errors.New("missing Vanta API token: pass --token or set VANTA_API_TOKEN")
 	}
 
 	repo := vantaRepo
@@ -224,7 +224,7 @@ func runDrataPush(cmd *cobra.Command, args []string) error {
 		token = os.Getenv("DRATA_API_TOKEN")
 	}
 	if token == "" && !drataDryRun {
-		return errors.New("Drata API token required: pass --token or set DRATA_API_TOKEN")
+		return errors.New("missing Drata API token: pass --token or set DRATA_API_TOKEN")
 	}
 
 	workspaceID := drataWorkspaceID

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -26,15 +26,15 @@ import (
 )
 
 var (
-	planFromRef       string
-	planToRef         string
-	planShowAll       bool
-	planMinimal       bool
-	planAnalyze       bool
-	planReview        bool
-	planMinConfidence float64
-	planDisableAI     bool
-	planSkipCognitive bool
+	planFromRef        string
+	planToRef          string
+	planShowAll        bool
+	planMinimal        bool
+	planAnalyze        bool
+	planReview         bool
+	planMinConfidence  float64
+	planDisableAI      bool
+	planSkipCognitive  bool
 	planChronosThreads int
 )
 

--- a/internal/cli/policy.go
+++ b/internal/cli/policy.go
@@ -383,7 +383,6 @@ func parsePolicyTestBumpType(value string) (cgp.BumpType, error) {
 	}
 }
 
-
 func toFloat64(v any) (float64, bool) {
 	switch n := v.(type) {
 	case float64:
@@ -593,4 +592,3 @@ func equalConditionSets(a, b []cgp.Condition) bool {
 func conditionKey(cond cgp.Condition) string {
 	return cond.Type + "|" + cond.Value
 }
-

--- a/internal/cli/policy_test_cmd.go
+++ b/internal/cli/policy_test_cmd.go
@@ -21,6 +21,7 @@ import (
 	"github.com/relicta-tech/relicta/internal/cgp"
 	"github.com/relicta-tech/relicta/internal/cgp/policy"
 )
+
 func runPolicyTest(cmd *cobra.Command, args []string) error {
 	if policyTestInput != "" && policyTestMatrix != "" {
 		return fmt.Errorf("--input and --matrix cannot be used together")
@@ -106,8 +107,6 @@ func runPolicyTest(cmd *cobra.Command, args []string) error {
 	}
 	return nil
 }
-
-
 
 // matrixScenarioName + matrixScenarioShard implemented in policy_matrix.go.
 
@@ -320,4 +319,3 @@ func resolvePolicyTestInput(cmd *cobra.Command) (*policyTestInputData, error) {
 	applied := applyPolicyTestDefaults(merged)
 	return &applied, nil
 }
-

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -28,16 +28,16 @@ var (
 	}
 
 	// Global flags
-	cfgFile       string
-	verbose       bool
-	dryRun        bool
-	outputJSON    bool
-	noColor       bool
-	logLevel      string
-	logLevelAlias string
-	modelFlag     string // --model flag for AI provider/model selection
-	ciMode        bool   // --ci flag for CI/CD pipeline mode (auto-approve, JSON output)
-	redactSecrets bool   // --redact flag to mask sensitive data in output
+	cfgFile               string
+	verbose               bool
+	dryRun                bool
+	outputJSON            bool
+	noColor               bool
+	logLevel              string
+	logLevelAlias         string
+	modelFlag             string // --model flag for AI provider/model selection
+	ciMode                bool   // --ci flag for CI/CD pipeline mode (auto-approve, JSON output)
+	redactSecrets         bool   // --redact flag to mask sensitive data in output
 	versionProbeCognitive bool
 
 	// allowUntrustedPlugins is the operator opt-in that bypasses the
@@ -495,7 +495,7 @@ func probeBackendHealth(baseURL string) string {
 	candidates := []string{base + "/health", base + "/healthz"}
 
 	for _, u := range candidates {
-		resp, err := client.Get(u) // #nosec G107 -- URL is operator-configured local endpoint
+		resp, err := client.Get(u) // #nosec G107 G704 -- URL is operator-configured local endpoint
 		if err != nil {
 			continue
 		}

--- a/internal/compliance/annex_iv.go
+++ b/internal/compliance/annex_iv.go
@@ -75,15 +75,15 @@ type GeneralDescription struct {
 
 // DetailedDescription is Annex IV §2 — how the system is built.
 type DetailedDescription struct {
-	DevelopmentMethods   []string `json:"developmentMethods"`
-	DesignSpecifications []string `json:"designSpecifications"`
-	SystemArchitecture   string   `json:"systemArchitecture"`
-	ComputationalResources string `json:"computationalResources,omitempty"`
-	DataRequirements     []string `json:"dataRequirements,omitempty"`
+	DevelopmentMethods     []string `json:"developmentMethods"`
+	DesignSpecifications   []string `json:"designSpecifications"`
+	SystemArchitecture     string   `json:"systemArchitecture"`
+	ComputationalResources string   `json:"computationalResources,omitempty"`
+	DataRequirements       []string `json:"dataRequirements,omitempty"`
 	HumanOversightMeasures []string `json:"humanOversightMeasures"`
-	PredeterminedChanges []string `json:"predeterminedChanges,omitempty"`
-	CGPProtocolVersion   string   `json:"cgpProtocolVersion"`
-	RiskModelVersion     string   `json:"riskModelVersion,omitempty"`
+	PredeterminedChanges   []string `json:"predeterminedChanges,omitempty"`
+	CGPProtocolVersion     string   `json:"cgpProtocolVersion"`
+	RiskModelVersion       string   `json:"riskModelVersion,omitempty"`
 }
 
 // MonitoringControl is Annex IV §3 — how the system is monitored and controlled.
@@ -96,19 +96,19 @@ type MonitoringControl struct {
 
 // RiskManagement is Annex IV §4 — how risks are identified, evaluated, mitigated.
 type RiskManagement struct {
-	IdentifiedRisks       []IdentifiedRisk      `json:"identifiedRisks"`
-	RiskEvaluationMethod  string                `json:"riskEvaluationMethod"`
-	RiskMitigationControls []MitigationControl  `json:"riskMitigationControls"`
-	ResidualRiskRationale string                `json:"residualRiskRationale,omitempty"`
+	IdentifiedRisks        []IdentifiedRisk    `json:"identifiedRisks"`
+	RiskEvaluationMethod   string              `json:"riskEvaluationMethod"`
+	RiskMitigationControls []MitigationControl `json:"riskMitigationControls"`
+	ResidualRiskRationale  string              `json:"residualRiskRationale,omitempty"`
 }
 
 // IdentifiedRisk records a risk category recognized by the system.
 type IdentifiedRisk struct {
-	Category    string  `json:"category"`
-	Description string  `json:"description"`
-	Severity    string  `json:"severity"`
-	OccurrenceCount int `json:"occurrenceCount"`
-	AverageScore float64 `json:"averageScore"`
+	Category        string  `json:"category"`
+	Description     string  `json:"description"`
+	Severity        string  `json:"severity"`
+	OccurrenceCount int     `json:"occurrenceCount"`
+	AverageScore    float64 `json:"averageScore"`
 }
 
 // MitigationControl describes a control applied to mitigate risk.
@@ -120,13 +120,13 @@ type MitigationControl struct {
 
 // LifecycleChange is a single change recorded against the system over time.
 type LifecycleChange struct {
-	Timestamp   time.Time `json:"timestamp"`
-	Version     string    `json:"version"`
-	ChangeType  string    `json:"changeType"`
-	Decision    string    `json:"decision"`
-	Actor       string    `json:"actor"`
-	Outcome     string    `json:"outcome"`
-	RiskScore   float64   `json:"riskScore"`
+	Timestamp  time.Time `json:"timestamp"`
+	Version    string    `json:"version"`
+	ChangeType string    `json:"changeType"`
+	Decision   string    `json:"decision"`
+	Actor      string    `json:"actor"`
+	Outcome    string    `json:"outcome"`
+	RiskScore  float64   `json:"riskScore"`
 }
 
 // HarmonizedStandard records compliance with an external framework or standard.
@@ -140,24 +140,24 @@ type HarmonizedStandard struct {
 // ConformityScaffold is Annex IV §7. Article 47 conformity declaration content
 // requires legal review; Relicta emits a scaffold for the provider to complete.
 type ConformityScaffold struct {
-	ProviderName       string `json:"providerName,omitempty"`
-	ProviderAddress    string `json:"providerAddress,omitempty"`
-	SystemIdentifier   string `json:"systemIdentifier"`
-	UniqueIdentifier   string `json:"uniqueIdentifier,omitempty"`
-	StandardsApplied   []string `json:"standardsApplied,omitempty"`
-	NotifiedBody       string `json:"notifiedBody,omitempty"`
-	DateOfDeclaration  string `json:"dateOfDeclaration,omitempty"`
-	Signatory          string `json:"signatory,omitempty"`
-	SignatoryRole      string `json:"signatoryRole,omitempty"`
+	ProviderName      string   `json:"providerName,omitempty"`
+	ProviderAddress   string   `json:"providerAddress,omitempty"`
+	SystemIdentifier  string   `json:"systemIdentifier"`
+	UniqueIdentifier  string   `json:"uniqueIdentifier,omitempty"`
+	StandardsApplied  []string `json:"standardsApplied,omitempty"`
+	NotifiedBody      string   `json:"notifiedBody,omitempty"`
+	DateOfDeclaration string   `json:"dateOfDeclaration,omitempty"`
+	Signatory         string   `json:"signatory,omitempty"`
+	SignatoryRole     string   `json:"signatoryRole,omitempty"`
 }
 
 // PostMarketMonitoring is Annex IV §8 — incident response + monitoring.
 type PostMarketMonitoring struct {
-	MonitoringPlan        string             `json:"monitoringPlan"`
-	IncidentRecords       []IncidentSummary8 `json:"incidentRecords"`
-	TotalIncidents        int                `json:"totalIncidents"`
-	AverageResolutionHrs  float64            `json:"averageResolutionHours"`
-	ChangeFailureRate     float64            `json:"changeFailureRate"`
+	MonitoringPlan       string             `json:"monitoringPlan"`
+	IncidentRecords      []IncidentSummary8 `json:"incidentRecords"`
+	TotalIncidents       int                `json:"totalIncidents"`
+	AverageResolutionHrs float64            `json:"averageResolutionHours"`
+	ChangeFailureRate    float64            `json:"changeFailureRate"`
 }
 
 // IncidentSummary8 is an incident record reformatted for §8 documentation.
@@ -271,7 +271,7 @@ func buildDetailedDescription(data *reportData) DetailedDescription {
 			"Hash-chained audit trail: internal/cgp/audit/",
 			"Hexagonal release aggregate: internal/domain/release/",
 		},
-		SystemArchitecture: "Hexagonal architecture with bounded contexts: domain (release aggregate, CGP), application (use cases), infrastructure (git, AI providers, persistence, webhooks), CLI (Cobra), MCP (server + adapters), httpserver (chi + middleware).",
+		SystemArchitecture:     "Hexagonal architecture with bounded contexts: domain (release aggregate, CGP), application (use cases), infrastructure (git, AI providers, persistence, webhooks), CLI (Cobra), MCP (server + adapters), httpserver (chi + middleware).",
 		ComputationalResources: "Single-binary CLI; optional PostgreSQL persistence backend. AI provider calls outsourced to OpenAI / Anthropic / Gemini / Ollama (per .relicta.yaml).",
 		DataRequirements: []string{
 			"git repository commit history",

--- a/internal/compliance/annex_iv_test.go
+++ b/internal/compliance/annex_iv_test.go
@@ -199,10 +199,10 @@ func TestRenderMarkdown_AnnexIVAllSections(t *testing.T) {
 				UserInterfaces:       []string{"CLI"},
 			},
 			DetailedDescription: DetailedDescription{
-				DevelopmentMethods: []string{"DDD"},
-				SystemArchitecture: "hexagonal",
+				DevelopmentMethods:     []string{"DDD"},
+				SystemArchitecture:     "hexagonal",
 				HumanOversightMeasures: []string{"approval gate"},
-				CGPProtocolVersion: "0.1",
+				CGPProtocolVersion:     "0.1",
 			},
 			MonitoringControl: MonitoringControl{
 				MonitoringMechanisms: []string{"Prometheus"},
@@ -232,8 +232,8 @@ func TestRenderMarkdown_AnnexIVAllSections(t *testing.T) {
 				DateOfDeclaration: "2026-05-02",
 			},
 			PostMarketMonitoring: PostMarketMonitoring{
-				MonitoringPlan:  "continuous",
-				TotalIncidents:  1,
+				MonitoringPlan:    "continuous",
+				TotalIncidents:    1,
 				ChangeFailureRate: 0.05,
 				IncidentRecords: []IncidentSummary8{
 					{IncidentID: "inc-1", ReleaseID: "rel-1", Version: "1.0.0", Type: "regression", Severity: "high", DetectedAt: now, ResolvedAt: &resolved, TimeToResolve: "2h"},

--- a/internal/compliance/article12_test.go
+++ b/internal/compliance/article12_test.go
@@ -260,9 +260,9 @@ func TestRenderCSV_NilReport(t *testing.T) {
 func TestGenerator_Render_JSONLRequiresArticle12(t *testing.T) {
 	gen := NewGenerator(memory.NewInMemoryStore(), nil)
 	report := &Report{
-		Type:    ReportSOC2,
-		Period:  Period{Start: time.Now(), End: time.Now().Add(time.Hour), Label: "x"},
-		SOC2:    &SOC2Report{},
+		Type:   ReportSOC2,
+		Period: Period{Start: time.Now(), End: time.Now().Add(time.Hour), Label: "x"},
+		SOC2:   &SOC2Report{},
 	}
 	if _, err := gen.Render(report, FormatJSONL); err == nil {
 		t.Error("expected error: jsonl format requires article12 report")

--- a/internal/compliance/report.go
+++ b/internal/compliance/report.go
@@ -46,11 +46,11 @@ func (f ReportFormat) IsValid() bool {
 type ReportType string
 
 const (
-	ReportDORA              ReportType = "dora"                 // DORA metrics
-	ReportSOC2              ReportType = "soc2"                 // SOC 2 change management evidence
-	ReportSummary           ReportType = "summary"              // General governance summary
-	ReportEUAIActArticle12  ReportType = "eu-ai-act-article-12" // EU AI Act Article 12 record-keeping
-	ReportEUAIActAnnexIV    ReportType = "eu-ai-act-annex-iv"   // EU AI Act Annex IV technical documentation
+	ReportDORA             ReportType = "dora"                 // DORA metrics
+	ReportSOC2             ReportType = "soc2"                 // SOC 2 change management evidence
+	ReportSummary          ReportType = "summary"              // General governance summary
+	ReportEUAIActArticle12 ReportType = "eu-ai-act-article-12" // EU AI Act Article 12 record-keeping
+	ReportEUAIActAnnexIV   ReportType = "eu-ai-act-annex-iv"   // EU AI Act Annex IV technical documentation
 )
 
 // IsValid returns true if the report type is recognized.

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -65,7 +65,7 @@ type App struct {
 	memoryStore        cgpmemory.Store
 
 	// Cognitive layer (optional — wired when configured)
-	mnemosStore   cgpmemory.Store            // Mnemos-backed memory store (optional)
+	mnemosStore   cgpmemory.Store              // Mnemos-backed memory store (optional)
 	chronosClient *chronosinfra.ChronosAdapter // Chronos pattern detection client
 
 	// Services (existing infrastructure)
@@ -231,7 +231,7 @@ func (c *App) initInfrastructure(ctx context.Context) error {
 		if chronosThreads <= 0 {
 			chronosThreads = 4
 		}
-		c.chronosClient = chronosinfra.NewChronosAdapterWithThreads(chronosEndpoint, "relicta", chronosThreads)
+		c.chronosClient = chronosinfra.NewChronosAdapterWithConfig(chronosEndpoint, "relicta", chronosThreads, chronosTimeout)
 		c.logger.Info("Chronos pattern detection initialized", "endpoint", chronosEndpoint)
 	}
 

--- a/internal/container/port_adapters.go
+++ b/internal/container/port_adapters.go
@@ -133,9 +133,11 @@ func (a *NotesGeneratorAdapter) generateReleaseNotesStructuredOrFreeForm(
 // the shim explicit clarifies the contract).
 type releaseNotesSchemaShim struct{}
 
-func (releaseNotesSchemaShim) Name() string        { return "ReleaseNotes" }
-func (releaseNotesSchemaShim) Description() string { return "Structured release notes with categorized sections." }
-func (releaseNotesSchemaShim) Strict() bool        { return false }
+func (releaseNotesSchemaShim) Name() string { return "ReleaseNotes" }
+func (releaseNotesSchemaShim) Description() string {
+	return "Structured release notes with categorized sections."
+}
+func (releaseNotesSchemaShim) Strict() bool { return false }
 func (releaseNotesSchemaShim) MarshalJSON() ([]byte, error) {
 	return []byte(`{
 		"type": "object",
@@ -166,8 +168,8 @@ func (releaseNotesSchemaShim) MarshalJSON() ([]byte, error) {
 // upgrade notes. Empty payload yields empty string so caller can fall back.
 func renderStructuredReleaseNotes(b []byte) (string, error) {
 	var payload struct {
-		Summary         string `json:"summary"`
-		Sections        []struct {
+		Summary  string `json:"summary"`
+		Sections []struct {
 			Category string   `json:"category"`
 			Items    []string `json:"items"`
 		} `json:"sections"`

--- a/internal/httpserver/handlers/health.go
+++ b/internal/httpserver/handlers/health.go
@@ -34,7 +34,7 @@ func Health(w http.ResponseWriter, r *http.Request) {
 
 // CognitiveHealthResponse is the response for the cognitive health endpoint.
 type CognitiveHealthResponse struct {
-	MnemosStatus string `json:"mnemos"`
+	MnemosStatus  string `json:"mnemos"`
 	ChronosStatus string `json:"chronos"`
 }
 
@@ -44,7 +44,7 @@ func CognitiveHealth(w http.ResponseWriter, r *http.Request) {
 	// Simplified: assume both are enabled (config default true).
 	// In a real implementation, we would ping the adapters or read status from the server.
 	resp := CognitiveHealthResponse{
-		MnemosStatus: "enabled",
+		MnemosStatus:  "enabled",
 		ChronosStatus: "enabled",
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/httpserver/router.go
+++ b/internal/httpserver/router.go
@@ -43,7 +43,11 @@ func (s *Server) setupRouter() chi.Router {
 
 	// All /api/v1 routes share API version negotiation
 	r.Route("/api/v1", func(r chi.Router) {
-		r.Use(chimw.RealIP) // RealIP inside API group, after global rate limiting
+		// chimw.RealIP was removed: it trusts X-Forwarded-For / X-Real-IP
+		// unconditionally (GHSA-3fxj-6jh8-hvhx), letting clients spoof their
+		// IP for rate limiting and audit logs. Direct peer address is the
+		// secure default; deployments behind a trusted proxy should resolve
+		// client IPs at the proxy layer.
 		r.Use(middleware.APIVersion())
 
 		// Health check (unauthenticated)

--- a/internal/infrastructure/ai/anthropic.go
+++ b/internal/infrastructure/ai/anthropic.go
@@ -226,13 +226,13 @@ func (s *anthropicService) CompleteStructured(ctx context.Context, systemPrompt,
 			if block.MessageContentToolUse == nil {
 				continue
 			}
-			if block.MessageContentToolUse.Name != schema.Name() {
+			if block.Name != schema.Name() {
 				continue
 			}
-			if len(block.MessageContentToolUse.Input) == 0 {
+			if len(block.Input) == 0 {
 				return "", errors.AI("CompleteStructured", "tool_use block has empty input")
 			}
-			return string(block.MessageContentToolUse.Input), nil
+			return string(block.Input), nil
 		}
 
 		return "", errors.AI("CompleteStructured", "no tool_use block matching schema in response")

--- a/internal/infrastructure/ai/evals/judge.go
+++ b/internal/infrastructure/ai/evals/judge.go
@@ -26,6 +26,16 @@ type Judge interface {
 	Score(ctx context.Context, golden Golden, output string) ([]Score, error)
 }
 
+// PassThresholder lets a judge declare pass gates matched to its own scoring
+// ceiling. Rubric defaults (mean >= 4.0) are written for LLM-grade judges;
+// a heuristic judge whose criteria are capped below 4 (e.g. DeterministicJudge
+// scores structured_output_valid at a fixed 3) could never pass them, turning
+// the gate into a permanent red light instead of a regression floor.
+// Thresholds declared here only fill gates the golden/rubric left unset.
+type PassThresholder interface {
+	PassThresholds() (minPass int, meanPass float64)
+}
+
 // DeterministicJudge is a heuristic, deterministic Judge that scores output
 // without external API calls. It applies a small set of rules:
 //
@@ -42,6 +52,12 @@ type DeterministicJudge struct{}
 
 // Name returns the judge identifier.
 func (DeterministicJudge) Name() string { return "deterministic" }
+
+// PassThresholds declares gates matched to this judge's heuristic ceiling:
+// healthy output scores ~3.8–4.0 (structured_output_valid is a fixed 3), so
+// the smoke floor is min >= 3 and mean >= 3.5. Empty output (all 1s), length
+// blow-ups, and topic drift (2s) still fail via the min gate.
+func (DeterministicJudge) PassThresholds() (int, float64) { return 3, 3.5 }
 
 // Score evaluates output via heuristic rules.
 func (DeterministicJudge) Score(_ context.Context, g Golden, output string) ([]Score, error) {
@@ -214,12 +230,12 @@ func finalize(v *Verdict, judgeName string) {
 }
 
 // aggregate computes weighted mean + minimum across a score list.
-func aggregate(scores []Score) (mean float64, min int) {
+func aggregate(scores []Score) (mean float64, lowest int) {
 	if len(scores) == 0 {
 		return 0, 0
 	}
 	var sum, totalWeight float64
-	min = 5
+	lowest = 5
 	for _, s := range scores {
 		w := float64(s.Weight)
 		if w == 0 {
@@ -227,14 +243,14 @@ func aggregate(scores []Score) (mean float64, min int) {
 		}
 		sum += float64(s.Value) * w
 		totalWeight += w
-		if s.Value < min {
-			min = s.Value
+		if s.Value < lowest {
+			lowest = s.Value
 		}
 	}
 	if totalWeight == 0 {
-		return 0, min
+		return 0, lowest
 	}
-	return sum / totalWeight, min
+	return sum / totalWeight, lowest
 }
 
 func weightOrOne(w int) int {

--- a/internal/infrastructure/ai/evals/judge_llm_test.go
+++ b/internal/infrastructure/ai/evals/judge_llm_test.go
@@ -214,7 +214,7 @@ func TestLLMJudge_PrefersStructuredOutputWhenSupported(t *testing.T) {
 		t.Errorf("expected EvalJudge schema, got %q", stub.structuredSchema)
 	}
 	// Free-form Complete must NOT have been called.
-	if stub.stubLLMService.response != "" {
+	if stub.response != "" {
 		t.Errorf("free-form Complete should not have been invoked")
 	}
 }

--- a/internal/infrastructure/ai/evals/runner.go
+++ b/internal/infrastructure/ai/evals/runner.go
@@ -113,7 +113,7 @@ func (r *Runner) runOne(ctx context.Context, g Golden) (Verdict, error) {
 	}
 	finalize(&v, r.cfg.Judge.Name())
 
-	v.Passed = passes(v, g)
+	v.Passed = passes(v, g, r.cfg.Judge)
 	return v, nil
 }
 
@@ -131,21 +131,28 @@ func (r *Runner) includes(c Category) bool {
 }
 
 // passes applies the rubric's MinPass / MeanPass gates plus any per-golden
-// override.
-func passes(v Verdict, g Golden) bool {
-	rubric := g.Rubric
-	if len(rubric.Criteria) == 0 {
-		rubric = DefaultRubric()
-	}
-
-	minPass := rubric.MinPass
+// override. Gates the golden/rubric leave unset fall back to thresholds the
+// judge declares for its own scoring ceiling (see PassThresholder), then to
+// the LLM-grade defaults (min 3, mean 4.0).
+func passes(v Verdict, g Golden, judge Judge) bool {
+	minPass := g.Rubric.MinPass
 	if g.MinPass > 0 {
 		minPass = g.MinPass
+	}
+	meanPass := g.Rubric.MeanPass
+
+	if jt, ok := judge.(PassThresholder); ok {
+		jMin, jMean := jt.PassThresholds()
+		if minPass == 0 {
+			minPass = jMin
+		}
+		if meanPass == 0 {
+			meanPass = jMean
+		}
 	}
 	if minPass == 0 {
 		minPass = 3
 	}
-	meanPass := rubric.MeanPass
 	if meanPass == 0 {
 		meanPass = 4.0
 	}

--- a/internal/infrastructure/ai/evals/runner_test.go
+++ b/internal/infrastructure/ai/evals/runner_test.go
@@ -210,13 +210,13 @@ func TestAggregate_WeightedMean(t *testing.T) {
 		{Value: 5, Weight: 2},
 		{Value: 3, Weight: 1},
 	}
-	mean, min := aggregate(scores)
+	mean, lowest := aggregate(scores)
 	want := (10.0 + 3.0) / 3.0
 	if mean != want {
 		t.Errorf("mean: got %v, want %v", mean, want)
 	}
-	if min != 3 {
-		t.Errorf("min: got %d, want 3", min)
+	if lowest != 3 {
+		t.Errorf("min: got %d, want 3", lowest)
 	}
 }
 
@@ -235,20 +235,53 @@ func TestPasses_RubricGates(t *testing.T) {
 		Rubric:   DefaultRubric(),
 	}
 
+	llm := &MockJudge{}
+
 	// Mean above + min above → passes.
-	pass := passes(Verdict{Mean: 4.5, Min: 4}, g)
+	pass := passes(Verdict{Mean: 4.5, Min: 4}, g, llm)
 	if !pass {
 		t.Error("expected pass for high scores")
 	}
 
 	// Mean below floor → fails.
-	if passes(Verdict{Mean: 3.0, Min: 4}, g) {
+	if passes(Verdict{Mean: 3.0, Min: 4}, g, llm) {
 		t.Error("expected fail when mean < MeanPass")
 	}
 
 	// Min below floor → fails.
-	if passes(Verdict{Mean: 4.5, Min: 2}, g) {
+	if passes(Verdict{Mean: 4.5, Min: 2}, g, llm) {
 		t.Error("expected fail when min < MinPass")
+	}
+}
+
+func TestPasses_JudgeDeclaredThresholds(t *testing.T) {
+	// Golden with no explicit gates — the judge's declared ceiling applies.
+	g := Golden{ID: "g", Category: CategoryReleaseNotes}
+	det := DeterministicJudge{}
+
+	// Healthy heuristic verdict (canned/noop output scores ~3.88) passes
+	// against the deterministic floor, where the LLM-grade 4.0 would fail.
+	if !passes(Verdict{Mean: 3.88, Min: 3}, g, det) {
+		t.Error("expected deterministic judge floor (mean 3.5) to pass mean 3.88")
+	}
+
+	// Degenerate output still fails the min gate.
+	if passes(Verdict{Mean: 3.6, Min: 2}, g, det) {
+		t.Error("expected fail when min < deterministic MinPass")
+	}
+	if passes(Verdict{Mean: 1.0, Min: 1}, g, det) {
+		t.Error("expected fail for empty-output scores")
+	}
+
+	// Explicit per-golden gates beat judge-declared thresholds.
+	strict := Golden{ID: "s", Category: CategoryReleaseNotes, Rubric: Rubric{MeanPass: 4.0, MinPass: 4}}
+	if passes(Verdict{Mean: 3.88, Min: 3}, strict, det) {
+		t.Error("expected explicit rubric gates to override judge thresholds")
+	}
+
+	// A judge without declared thresholds keeps the LLM-grade defaults.
+	if passes(Verdict{Mean: 3.88, Min: 3}, g, &MockJudge{}) {
+		t.Error("expected default mean gate 4.0 for judges without PassThresholds")
 	}
 }
 
@@ -318,4 +351,6 @@ func TestLLMJudge_NoServiceErrors(t *testing.T) {
 // serviceFn lets tests use a closure as Service without defining a struct.
 type serviceFn func(ctx context.Context, systemPrompt, userPrompt string) (string, error)
 
-func (f serviceFn) Complete(ctx context.Context, sp, up string) (string, error) { return f(ctx, sp, up) }
+func (f serviceFn) Complete(ctx context.Context, sp, up string) (string, error) {
+	return f(ctx, sp, up)
+}

--- a/internal/infrastructure/ai/evals/types.go
+++ b/internal/infrastructure/ai/evals/types.go
@@ -112,10 +112,10 @@ func DefaultRubric() Rubric {
 
 // Score is one criterion's judgment.
 type Score struct {
-	Criterion string  `json:"criterion"`
-	Value     int     `json:"value"`     // 1-5
-	Rationale string  `json:"rationale"` // judge's brief justification
-	Weight    int     `json:"weight"`
+	Criterion string `json:"criterion"`
+	Value     int    `json:"value"`     // 1-5
+	Rationale string `json:"rationale"` // judge's brief justification
+	Weight    int    `json:"weight"`
 }
 
 // Verdict is the judge's evaluation of one Golden's output.
@@ -142,10 +142,10 @@ type Run struct {
 
 // Summary is per-category aggregation suitable for CI status output.
 type Summary struct {
-	Total     int                       `json:"total"`
-	Passed    int                       `json:"passed"`
-	Failed    int                       `json:"failed"`
-	OverallMean float64                 `json:"overallMean"`
+	Total       int                      `json:"total"`
+	Passed      int                      `json:"passed"`
+	Failed      int                      `json:"failed"`
+	OverallMean float64                  `json:"overallMean"`
 	ByCategory  map[Category]CategoryAgg `json:"byCategory"`
 }
 

--- a/internal/infrastructure/ai/schemas/schemas.go
+++ b/internal/infrastructure/ai/schemas/schemas.go
@@ -44,10 +44,10 @@ type rawSchema struct {
 	doc         any
 }
 
-func (r rawSchema) Name() string                    { return r.name }
-func (r rawSchema) Description() string             { return r.description }
-func (r rawSchema) Strict() bool                    { return r.strict }
-func (r rawSchema) MarshalJSON() ([]byte, error)    { return json.Marshal(r.doc) }
+func (r rawSchema) Name() string                 { return r.name }
+func (r rawSchema) Description() string          { return r.description }
+func (r rawSchema) Strict() bool                 { return r.strict }
+func (r rawSchema) MarshalJSON() ([]byte, error) { return json.Marshal(r.doc) }
 
 // GovernanceDecisionSchema is the schema for AI-generated governance decision
 // summaries. Used by `relicta_evaluate` and risk-narrative tools.

--- a/internal/infrastructure/ai/service.go
+++ b/internal/infrastructure/ai/service.go
@@ -147,9 +147,9 @@ type CustomPrompts struct {
 
 // DefaultOpenAIModel is the default OpenAI model. 2026 default: gpt-5.
 const (
-	DefaultOpenAIModel        = "gpt-5"
-	OpenAIModelHighStakes     = "gpt-5"      // governance-sensitive prose
-	OpenAIModelFast           = "gpt-5-mini" // fast/cheap for diff summaries
+	DefaultOpenAIModel    = "gpt-5"
+	OpenAIModelHighStakes = "gpt-5"      // governance-sensitive prose
+	OpenAIModelFast       = "gpt-5-mini" // fast/cheap for diff summaries
 )
 
 // DefaultServiceConfig returns the default service configuration.

--- a/internal/infrastructure/chronos/chronos.go
+++ b/internal/infrastructure/chronos/chronos.go
@@ -18,9 +18,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/relicta-tech/relicta/internal/cgp"
 	"github.com/relicta-tech/relicta/internal/cgp/memory"
-	"github.com/rs/zerolog/log"
 )
 
 // ChronosAdapter implements memory.Store using Chronos for pattern detection.
@@ -34,8 +35,8 @@ type ChronosAdapter struct {
 
 // ChronosIngestRequest represents an ingest request to Chronos.
 type ChronosIngestRequest struct {
-	EntityID string                 `json:"entity_id"`
-	ScopeID  string                 `json:"scope_id"`
+	EntityID  string                 `json:"entity_id"`
+	ScopeID   string                 `json:"scope_id"`
 	Timestamp time.Time              `json:"timestamp"`
 	Features  []float64              `json:"features"`
 	Labels    []string               `json:"labels,omitempty"`
@@ -44,15 +45,15 @@ type ChronosIngestRequest struct {
 
 // ChronosSignal represents a pattern signal from Chronos.
 type ChronosSignal struct {
-	ID         string             `json:"id"`
-	ScopeID    string             `json:"scope_id"`
-	Series     string             `json:"series"`
-	Pattern    string             `json:"pattern"`
-	DetectedAt time.Time        `json:"detected_at"`
-	Strength   float64            `json:"strength"`
-	Confidence float64            `json:"confidence"`
+	ID         string            `json:"id"`
+	ScopeID    string            `json:"scope_id"`
+	Series     string            `json:"series"`
+	Pattern    string            `json:"pattern"`
+	DetectedAt time.Time         `json:"detected_at"`
+	Strength   float64           `json:"strength"`
+	Confidence float64           `json:"confidence"`
 	Window     ChronosWindow     `json:"window"`
-	Metrics    ChronosMetrics     `json:"metrics"`
+	Metrics    ChronosMetrics    `json:"metrics"`
 	Evidence   []ChronosEvidence `json:"evidence"`
 }
 
@@ -65,8 +66,8 @@ type ChronosWindow struct {
 // ChronosMetrics contains detection metrics.
 type ChronosMetrics struct {
 	NormalizedStdDev float64 `json:"normalised_stddev"`
-	Mean            float64 `json:"mean"`
-	N               int     `json:"n"`
+	Mean             float64 `json:"mean"`
+	N                int     `json:"n"`
 }
 
 // ChronosEvidence represents evidence for a signal.
@@ -90,15 +91,24 @@ func NewChronosAdapter(baseURL, scopeID string) *ChronosAdapter {
 
 // NewChronosAdapterWithThreads creates a Chronos adapter with bounded ingest concurrency.
 func NewChronosAdapterWithThreads(baseURL, scopeID string, threads int) *ChronosAdapter {
+	return NewChronosAdapterWithConfig(baseURL, scopeID, threads, 0)
+}
+
+// NewChronosAdapterWithConfig creates a Chronos adapter with bounded ingest
+// concurrency and a custom HTTP timeout. A zero timeout defaults to 10s.
+func NewChronosAdapterWithConfig(baseURL, scopeID string, threads int, timeout time.Duration) *ChronosAdapter {
 	if baseURL == "" {
 		baseURL = "http://localhost:7778"
 	}
 	if threads <= 0 {
 		threads = 1
 	}
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
 	return &ChronosAdapter{
 		baseURL:    baseURL,
-		httpClient: &http.Client{Timeout: 10 * time.Second},
+		httpClient: &http.Client{Timeout: timeout},
 		scopeID:    scopeID,
 		sem:        make(chan struct{}, threads),
 	}
@@ -128,17 +138,17 @@ func (a *ChronosAdapter) RecordRelease(ctx context.Context, record *memory.Relea
 	features = append(features, outcomeNum)
 
 	req := ChronosIngestRequest{
-		EntityID: record.ID,
-		ScopeID:  a.scopeID,
+		EntityID:  record.ID,
+		ScopeID:   a.scopeID,
 		Timestamp: record.ReleasedAt,
 		Features:  features,
 		Labels:    []string{"release", string(record.Decision)},
 		Metadata: map[string]interface{}{
-			"repository":  record.Repository,
-			"version":     record.Version,
-			"actor_id":    record.Actor.ID,
-			"actor_kind":  string(record.Actor.Kind),
-			"outcome":     string(record.Outcome),
+			"repository": record.Repository,
+			"version":    record.Version,
+			"actor_id":   record.Actor.ID,
+			"actor_kind": string(record.Actor.Kind),
+			"outcome":    string(record.Outcome),
 		},
 	}
 
@@ -149,17 +159,17 @@ func (a *ChronosAdapter) RecordRelease(ctx context.Context, record *memory.Relea
 func (a *ChronosAdapter) RecordIncident(ctx context.Context, incident *memory.IncidentRecord) error {
 	// Incidents are recorded as a spike in a special "incident" series
 	req := ChronosIngestRequest{
-		EntityID: incident.ID,
-		ScopeID:  a.scopeID,
+		EntityID:  incident.ID,
+		ScopeID:   a.scopeID,
 		Timestamp: incident.DetectedAt,
 		Features:  []float64{1.0}, // Spike value
 		Labels:    []string{"incident", string(incident.Type)},
 		Metadata: map[string]interface{}{
-			"repository":   incident.Repository,
-			"release_id":  incident.ReleaseID,
-			"version":     incident.Version,
-			"severity":    string(incident.Severity),
-			"actor_id":    incident.ActorID,
+			"repository": incident.Repository,
+			"release_id": incident.ReleaseID,
+			"version":    incident.Version,
+			"severity":   string(incident.Severity),
+			"actor_id":   incident.ActorID,
 		},
 	}
 
@@ -224,8 +234,8 @@ func (a *ChronosAdapter) GetActorMetrics(ctx context.Context, actorID string) (*
 // This is the key method - it detects trending, spikes, stalls in risk.
 func (a *ChronosAdapter) GetRiskPatterns(ctx context.Context, repository string) (*memory.RiskPatterns, error) {
 	patterns := &memory.RiskPatterns{
-		Repository:    repository,
-		UpdatedAt:     time.Now(),
+		Repository: repository,
+		UpdatedAt:  time.Now(),
 	}
 
 	// Query Chronos for signals on the risk series

--- a/internal/infrastructure/chronos/chronos_test.go
+++ b/internal/infrastructure/chronos/chronos_test.go
@@ -50,7 +50,7 @@ func TestChronosAdapter_RecordRelease(t *testing.T) {
 		ID:         "rel-1",
 		Repository: "github.com/example/repo",
 		Version:    "v1.0.0",
-		Actor:       cgp.Actor{ID: "alice", Kind: cgp.ActorKindHuman},
+		Actor:      cgp.Actor{ID: "alice", Kind: cgp.ActorKindHuman},
 		RiskScore:  0.25,
 		Decision:   cgp.DecisionApproved,
 		Outcome:    memory.OutcomeSuccess,

--- a/internal/infrastructure/hubsync/client.go
+++ b/internal/infrastructure/hubsync/client.go
@@ -133,8 +133,8 @@ func (c *Client) attempt(ctx context.Context, url string, payload []byte) (*Sync
 
 	body, _ := io.ReadAll(resp.Body)
 
-	switch {
-	case resp.StatusCode == http.StatusAccepted, resp.StatusCode == http.StatusMultiStatus:
+	switch resp.StatusCode {
+	case http.StatusAccepted, http.StatusMultiStatus:
 		// 202 (all accepted) and 207 (partial) both decode the same body.
 		var parsed SyncResponse
 		if err := json.Unmarshal(body, &parsed); err != nil {
@@ -145,12 +145,12 @@ func (c *Client) attempt(ctx context.Context, url string, payload []byte) (*Sync
 		}
 		return &parsed, nil
 
-	case resp.StatusCode == http.StatusPreconditionFailed:
+	case http.StatusPreconditionFailed:
 		// Schema version mismatch — terminal: a CLI upgrade is the fix,
 		// not a retry.
 		return nil, &VersionMismatchError{Body: string(body)}
 
-	case resp.StatusCode == http.StatusServiceUnavailable:
+	case http.StatusServiceUnavailable:
 		// Hub draining — operator pulled the instance from rotation. The
 		// caller's queue should kick in and try again later.
 		retryAfter := resp.Header.Get("Retry-After")

--- a/internal/infrastructure/memory/mnemos.go
+++ b/internal/infrastructure/memory/mnemos.go
@@ -20,9 +20,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/relicta-tech/relicta/internal/cgp"
 	"github.com/relicta-tech/relicta/internal/cgp/memory"
-	"github.com/rs/zerolog/log"
 )
 
 // MnemosAdapter implements memory.Store using Mnemos HTTP API.

--- a/internal/infrastructure/memory/mnemos_bench_test.go
+++ b/internal/infrastructure/memory/mnemos_bench_test.go
@@ -19,13 +19,13 @@ func BenchmarkMnemosRecordRelease(b *testing.B) {
 
 	rec := &memory.ReleaseRecord{
 		ID:         "bench-rel",
-		Version:     "v0.0.1",
-		Repository:  "bench/repo",
-		Actor:       cgp.Actor{ID: "bench", Kind: cgp.ActorKindHuman},
-		RiskScore:   0.5,
-		Decision:    cgp.DecisionApproved,
-		Outcome:     memory.OutcomeSuccess,
-		ReleasedAt:  time.Now().UTC(),
+		Version:    "v0.0.1",
+		Repository: "bench/repo",
+		Actor:      cgp.Actor{ID: "bench", Kind: cgp.ActorKindHuman},
+		RiskScore:  0.5,
+		Decision:   cgp.DecisionApproved,
+		Outcome:    memory.OutcomeSuccess,
+		ReleasedAt: time.Now().UTC(),
 	}
 
 	b.ResetTimer()

--- a/internal/infrastructure/memory/mnemos_test.go
+++ b/internal/infrastructure/memory/mnemos_test.go
@@ -15,66 +15,68 @@ import (
 
 // simple in‑memory event store used by the test server
 type eventStore struct {
-    events []MnemosEvent
+	events []MnemosEvent
 }
 
 func (s *eventStore) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-    switch r.Method {
-    case http.MethodPost:
-        // Expect POST /v1/events (Mnemos default path)
-        var payload struct{ Events []MnemosEvent `json:"events"` }
-        json.NewDecoder(r.Body).Decode(&payload)
-        s.events = append(s.events, payload.Events...)
-        w.WriteHeader(http.StatusCreated)
-    case http.MethodGet:
-        // Return stored events as MnemosQueryResponse
-        resp := MnemosQueryResponse{Events: s.events, Total: len(s.events)}
-        json.NewEncoder(w).Encode(resp)
-    default:
-        http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-    }
+	switch r.Method {
+	case http.MethodPost:
+		// Expect POST /v1/events (Mnemos default path)
+		var payload struct {
+			Events []MnemosEvent `json:"events"`
+		}
+		json.NewDecoder(r.Body).Decode(&payload)
+		s.events = append(s.events, payload.Events...)
+		w.WriteHeader(http.StatusCreated)
+	case http.MethodGet:
+		// Return stored events as MnemosQueryResponse
+		resp := MnemosQueryResponse{Events: s.events, Total: len(s.events)}
+		json.NewEncoder(w).Encode(resp)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
 }
 
 func newTestServer() (*httptest.Server, *eventStore) {
-    store := &eventStore{}
-    srv := httptest.NewServer(store)
-    return srv, store
+	store := &eventStore{}
+	srv := httptest.NewServer(store)
+	return srv, store
 }
 
 func TestMnemosAdapter_RecordRelease_And_GetReleaseHistory(t *testing.T) {
-    srv, _ := newTestServer()
-    defer srv.Close()
+	srv, _ := newTestServer()
+	defer srv.Close()
 
-    // Use the test server URL as baseURL (Mnemos expects /v1/events endpoint)
-    adapter := NewMnemosStore(srv.URL+"/v1", "test-run", nil)
+	// Use the test server URL as baseURL (Mnemos expects /v1/events endpoint)
+	adapter := NewMnemosStore(srv.URL+"/v1", "test-run", nil)
 
-    // Build a minimal ReleaseRecord matching the memory schema.
-    rec := &memory.ReleaseRecord{
-        ID:                "rel-1",
-        Version:           "v1.0.0",
-        Repository:        "github.com/example/repo",
-		Actor:             cgp.Actor{ID: "alice", Kind: cgp.ActorKindHuman},
-		RiskScore:         0.12,
-		Decision:          cgp.DecisionApproved,
-        Outcome:           memory.OutcomeSuccess,
-        BreakingChanges:   0,
-        FilesChanged:      5,
-        LinesChanged:      123,
-        ReleasedAt:        time.Now().UTC(),
-    }
+	// Build a minimal ReleaseRecord matching the memory schema.
+	rec := &memory.ReleaseRecord{
+		ID:              "rel-1",
+		Version:         "v1.0.0",
+		Repository:      "github.com/example/repo",
+		Actor:           cgp.Actor{ID: "alice", Kind: cgp.ActorKindHuman},
+		RiskScore:       0.12,
+		Decision:        cgp.DecisionApproved,
+		Outcome:         memory.OutcomeSuccess,
+		BreakingChanges: 0,
+		FilesChanged:    5,
+		LinesChanged:    123,
+		ReleasedAt:      time.Now().UTC(),
+	}
 
-    if err := adapter.RecordRelease(context.Background(), rec); err != nil {
-        t.Fatalf("RecordRelease failed: %v", err)
-    }
+	if err := adapter.RecordRelease(context.Background(), rec); err != nil {
+		t.Fatalf("RecordRelease failed: %v", err)
+	}
 
-    // Retrieve history – limit 10 should return the single record.
-    history, err := adapter.GetReleaseHistory(context.Background(), "github.com/example/repo", 10)
-    if err != nil {
-        t.Fatalf("GetReleaseHistory error: %v", err)
-    }
-    if len(history) != 1 {
-        t.Fatalf("expected 1 record, got %d", len(history))
-    }
+	// Retrieve history – limit 10 should return the single record.
+	history, err := adapter.GetReleaseHistory(context.Background(), "github.com/example/repo", 10)
+	if err != nil {
+		t.Fatalf("GetReleaseHistory error: %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(history))
+	}
 	if history[0].ID != "release-rel-1" {
 		t.Fatalf("unexpected record ID: %s", history[0].ID)
 	}

--- a/internal/integrations/vanta/client_test.go
+++ b/internal/integrations/vanta/client_test.go
@@ -306,9 +306,9 @@ func TestMapSOC2_NilOrMissing(t *testing.T) {
 
 func TestDescribeEntry_Verifiers(t *testing.T) {
 	one := describeEntry(compliance.Article12LogEntry{
-		Actor:    cgp.Actor{Kind: cgp.ActorKindAgent, ID: "x"},
+		Actor:          cgp.Actor{Kind: cgp.ActorKindAgent, ID: "x"},
 		OutputDecision: "approved",
-		Verifiers: []compliance.Verifier{{Kind: "human", ID: "a"}},
+		Verifiers:      []compliance.Verifier{{Kind: "human", ID: "a"}},
 	})
 	if !strings.Contains(one, "1 verifier") {
 		t.Errorf("expected '1 verifier' in description, got %q", one)

--- a/internal/integrations/vanta/mapping.go
+++ b/internal/integrations/vanta/mapping.go
@@ -22,7 +22,7 @@ const (
 	// EvidenceTypeAuditLog covers Article 12 / hash-chained audit entries.
 	EvidenceTypeAuditLog EvidenceType = "audit_log"
 
-	// EvidenceTypeRiskAssessment covers risk evaluation artefacts.
+	// EvidenceTypeRiskAssessment covers risk evaluation artifacts.
 	EvidenceTypeRiskAssessment EvidenceType = "risk_assessment"
 )
 
@@ -34,7 +34,7 @@ type FrameworkMapping struct {
 
 // Evidence is the Vanta custom-evidence payload.
 //
-// The shape is intentionally generic so it can carry any Relicta artefact
+// The shape is intentionally generic so it can carry any Relicta artifact
 // (Article 12 log entry, governance decision, approval record, full SOC 2
 // report). Vanta's custom-evidence API accepts arbitrary JSON in `data`.
 type Evidence struct {
@@ -179,7 +179,7 @@ func MapSOC2(report *compliance.Report) []Evidence {
 			SystemIdentifier: systemID,
 			Frameworks:       soc2Frameworks,
 			Data: map[string]any{
-				"period":     report.Period,
+				"period":      report.Period,
 				"assessments": report.SOC2.RiskAssessments,
 			},
 		},

--- a/internal/mcp/adapters.go
+++ b/internal/mcp/adapters.go
@@ -1168,7 +1168,7 @@ func enrichDiffSummaryWithStructuredAI(
 		return
 	}
 
-	systemPrompt := "You are a release-governance assistant. Analyse the diff and return structured signals."
+	systemPrompt := "You are a release-governance assistant. Analyze the diff and return structured signals."
 	userPrompt := buildDiffStructuredPrompt(input, result)
 
 	bytes, err := structured.CompleteStructured(ctx, systemPrompt, userPrompt, schemas.DiffSummarySchema())
@@ -1211,7 +1211,7 @@ func buildDiffStructuredPrompt(input SummarizeDiffInput, result *servicerelease.
 	}
 	summary := result.ChangeSet.Summary()
 	return fmt.Sprintf(
-		"Analyse a release diff for audience=%q.\n"+
+		"Analyze a release diff for audience=%q.\n"+
 			"Total commits: %d. From=%s To=%s.\n"+
 			"Return a structured DiffSummary with summary text, categories observed, and boolean risk signals.",
 		input.Audience,

--- a/internal/mcp/autonomy.go
+++ b/internal/mcp/autonomy.go
@@ -21,8 +21,8 @@ const MCPActorKind = "agent"
 // tool invocation. The error message lists every violation so callers can
 // surface the full failure reason without a second round-trip.
 type MCPBudgetDenialError struct {
-	Tool       string
-	Decision   policy.Decision
+	Tool     string
+	Decision policy.Decision
 }
 
 func (e *MCPBudgetDenialError) Error() string {

--- a/internal/observability/monitor/health.go
+++ b/internal/observability/monitor/health.go
@@ -103,7 +103,7 @@ func (hm *HealthMonitor) StartWatch(ctx context.Context, releaseID string) error
 		return fmt.Errorf("watch already active for release: %s", releaseID)
 	}
 
-	watchCtx, cancel := context.WithCancel(ctx) //nolint:gosec // cancel is stored in watch.cancel and called by StopWatch
+	watchCtx, cancel := context.WithCancel(ctx) // cancel is stored in watch.cancel and called by StopWatch
 	now := time.Now()
 
 	watch := &releaseWatch{

--- a/internal/security/oidc/oidc_test.go
+++ b/internal/security/oidc/oidc_test.go
@@ -131,7 +131,7 @@ func (m *mockOIDCProvider) handleAuthorize(w http.ResponseWriter, r *http.Reques
 	// with a code and the state parameter.
 	state := r.URL.Query().Get("state")
 	redirectURI := r.URL.Query().Get("redirect_uri")
-	http.Redirect(w, r, redirectURI+"?code=mock-auth-code&state="+state, http.StatusFound)
+	http.Redirect(w, r, redirectURI+"?code=mock-auth-code&state="+state, http.StatusFound) // #nosec G710 -- test-only mock IdP echoing the client-supplied redirect_uri
 }
 
 func (m *mockOIDCProvider) close() {

--- a/pkg/cgp/approval_card_test.go
+++ b/pkg/cgp/approval_card_test.go
@@ -75,7 +75,7 @@ func TestApprovalCard_RoundTripJSON(t *testing.T) {
 				{Category: "auth", Description: "touches authentication", Score: 0.6, Severity: "high"},
 			},
 		},
-		Actor: Actor{Kind: "agent", ID: "claude-code-1"},
+		Actor:            Actor{Kind: "agent", ID: "claude-code-1"},
 		Decision:         "approval_required",
 		Rationale:        []string{"breaking change requires manual review"},
 		AvailableActions: CanonicalActions(),
@@ -106,14 +106,14 @@ func TestApprovalCard_RoundTripJSON(t *testing.T) {
 
 func TestApprovalCard_OmitemptyFieldsWhenAbsent(t *testing.T) {
 	minimal := ApprovalCard{
-		CGPVersion: "0.1",
-		CardID:     "x",
-		ReleaseID:  "y",
-		Risk:       RiskBlock{Score: 0.1, Tier: "low", Severity: "LOW"},
-		Actor:      Actor{Kind: "human", ID: "alice@example.com"},
-		Decision:   "approved",
+		CGPVersion:       "0.1",
+		CardID:           "x",
+		ReleaseID:        "y",
+		Risk:             RiskBlock{Score: 0.1, Tier: "low", Severity: "LOW"},
+		Actor:            Actor{Kind: "human", ID: "alice@example.com"},
+		Decision:         "approved",
 		AvailableActions: CanonicalActions(),
-		CreatedAt:  time.Now().UTC(),
+		CreatedAt:        time.Now().UTC(),
 	}
 	b, _ := json.Marshal(&minimal)
 	body := string(b)


### PR DESCRIPTION
Every CI run on main has failed at workflow parse since May 6: the `integration` job's `needs: [test]` references a job that was renamed to `lint-and-test`, making `ci.yaml` invalid.

GitHub reports these runs as: *"This run likely failed because of a workflow file issue."*

This also explains why dependabot PRs show incomplete/odd check rollups — the CI workflow never starts.

Fix: `needs: [test]` → `needs: [lint-and-test]`.