### PR TITLE
fix(release): migrate checksum signing to cosign v3 bundle format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -101,16 +101,18 @@ upx:
       - linux
       - darwin
 
-# Sign checksums
+# Sign checksums with the cosign v3 bundle format (single .sigstore.json
+# bundle replaces the .pem/.sig pair; v3 sign-blob errors without --bundle).
+# Verify with: cosign verify-blob --bundle checksums.txt.sigstore.json \
+#   --certificate-identity-regexp 'github.com/relicta-tech/relicta' \
+#   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+#   checksums.txt
 signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
       - --yes
     artifacts: checksum


### PR DESCRIPTION
The v4.0.2 release run failed at the GoReleaser signing step:

```
Error: signing dist/checksums.txt: create bundle file: open : no such file or directory
```

Cause: #121 bumped `sigstore/cosign-installer` to v4, which installs **cosign v3**. v3's `sign-blob` requires `--bundle` and no longer works with the `--output-certificate`/`--output-signature` pair.

Fix: emit a single `checksums.txt.sigstore.json` bundle (the v3-native format). Verification:

```bash
cosign verify-blob --bundle checksums.txt.sigstore.json \
  --certificate-identity-regexp 'github.com/relicta-tech/relicta' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  checksums.txt
```

No docs referenced the old `.pem`/`.sig` artifact names. After merge: delete tag v4.0.2, re-tag on main, rerun release.