### PR TITLE
feat(plugin): required-plugin pinning with no-arg install (ADR-008 Phase 3)

### DIFF
--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -47,13 +48,22 @@ from the registry.`,
 }
 
 var pluginInstallCmd = &cobra.Command{
-	Use:   "install <name>",
-	Short: "Install a plugin",
+	Use:   "install [name]",
+	Short: "Install a plugin (or all required plugins)",
 	Long: `Install a plugin from the registry.
 
 Downloads the plugin binary for your platform and makes it available
-for use. Plugins must be enabled after installation with 'plugin enable'.`,
-	Args: cobra.ExactArgs(1),
+for use. Plugins must be enabled after installation with 'plugin enable'.
+
+With no arguments, resolves and installs every plugin pinned in
+plugin_security.required (ADR-008), skipping requirements that are
+already satisfied:
+
+  plugin_security:
+    required:
+      - github@^2.0
+      - slack`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: runPluginInstall,
 }
 
@@ -317,12 +327,18 @@ func getCategoryTitle(category string) string {
 
 func runPluginInstall(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	pluginName := args[0]
 
 	mgr, err := newPluginManager()
 	if err != nil {
 		return fmt.Errorf("failed to create plugin manager: %w", err)
 	}
+
+	// No argument: install the project's required set (ADR-008).
+	if len(args) == 0 {
+		return runPluginInstallRequired(ctx, mgr)
+	}
+
+	pluginName := args[0]
 
 	fmt.Printf("Installing plugin %q...\n", pluginName)
 
@@ -337,6 +353,36 @@ func runPluginInstall(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  1. Enable it: relicta plugin enable %s\n", pluginName)
 	fmt.Printf("  2. Configure it in .relicta.yaml\n")
 
+	return nil
+}
+
+// runPluginInstallRequired installs every spec from plugin_security.required.
+func runPluginInstallRequired(ctx context.Context, mgr pluginManager) error {
+	if cfg == nil || len(cfg.PluginSecurity.Required) == 0 {
+		printInfo("No required plugins configured (plugin_security.required is empty)")
+		return nil
+	}
+
+	results, err := mgr.InstallRequired(ctx, cfg.PluginSecurity.Required)
+	if err != nil {
+		return err
+	}
+
+	var failed int
+	for _, r := range results {
+		switch {
+		case r.Err != nil:
+			failed++
+			printError(fmt.Sprintf("%s: %v", r.Spec, r.Err))
+		case r.Installed:
+			printSuccess(fmt.Sprintf("%s: installed %s", r.Spec, r.Version))
+		default:
+			printInfo(fmt.Sprintf("%s: already satisfied (%s)", r.Spec, r.Version))
+		}
+	}
+	if failed > 0 {
+		return fmt.Errorf("%d of %d required plugins failed to install", failed, len(results))
+	}
 	return nil
 }
 

--- a/internal/cli/plugin_command_test.go
+++ b/internal/cli/plugin_command_test.go
@@ -57,6 +57,14 @@ func (s *stubPluginManager) Install(ctx context.Context, name string) error {
 	return s.install(ctx, name)
 }
 
+func (s *stubPluginManager) InstallRequired(ctx context.Context, specs []string) ([]manager.RequiredResult, error) {
+	results := make([]manager.RequiredResult, 0, len(specs))
+	for _, spec := range specs {
+		results = append(results, manager.RequiredResult{Spec: spec, Installed: true})
+	}
+	return results, nil
+}
+
 func (s *stubPluginManager) Uninstall(ctx context.Context, name string) error {
 	return s.uninstall(ctx, name)
 }

--- a/internal/cli/plugin_manager_injection.go
+++ b/internal/cli/plugin_manager_injection.go
@@ -10,6 +10,7 @@ type pluginManager interface {
 	ListAvailable(context.Context, bool) ([]manager.PluginListEntry, error)
 	ListInstalled(context.Context) ([]manager.PluginListEntry, error)
 	Install(context.Context, string) error
+	InstallRequired(context.Context, []string) ([]manager.RequiredResult, error)
 	Uninstall(context.Context, string) error
 	Enable(context.Context, string) error
 	Disable(context.Context, string) error

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -311,6 +311,13 @@ type PluginSecurityConfig struct {
 	// TrustKey is the path to the operator-managed public key required
 	// by the enterprise trust policy.
 	TrustKey string `mapstructure:"trust_key" json:"trust_key,omitempty"`
+	// Required pins the plugins this project needs, package.json-style:
+	// "name" or "name@constraint" ("github@^2.0"). `relicta plugin install`
+	// with no arguments resolves and installs the full set.
+	Required []string `mapstructure:"required" json:"required,omitempty"`
+	// AutoInstall installs missing required plugins automatically before
+	// release commands run. Defaults to true when Required is non-empty.
+	AutoInstall *bool `mapstructure:"auto_install" json:"auto_install,omitempty"`
 }
 
 // PluginConfig configures a single plugin.

--- a/internal/plugin/manager/manager.go
+++ b/internal/plugin/manager/manager.go
@@ -272,6 +272,84 @@ func (m *Manager) Install(ctx context.Context, name string) error {
 	return nil
 }
 
+// RequiredResult reports the outcome for one required-plugin spec.
+type RequiredResult struct {
+	Spec      string
+	Installed bool   // true when an install was performed
+	Skipped   bool   // true when the requirement was already satisfied
+	Version   string // version now present
+	Err       error
+}
+
+// InstallRequired resolves and installs a set of required-plugin specs
+// ("name" or "name@constraint", ADR-008). Already-satisfied requirements
+// are skipped; the registry version must satisfy the constraint for an
+// install to proceed. All specs are processed; per-spec failures are
+// reported in the results rather than aborting the set.
+func (m *Manager) InstallRequired(ctx context.Context, specs []string) ([]RequiredResult, error) {
+	reqs, err := ParseRequirements(specs)
+	if err != nil {
+		return nil, err
+	}
+
+	manifest, err := m.getOrCreateManifest()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load manifest: %w", err)
+	}
+
+	actions := ResolveRequired(reqs, manifest.Installed)
+
+	var (
+		results  []RequiredResult
+		registry *Registry
+	)
+	for _, action := range actions {
+		res := RequiredResult{Spec: action.Requirement.Raw}
+		if !action.Install {
+			res.Skipped = true
+			for _, p := range manifest.Installed {
+				if p.Name == action.Requirement.Name {
+					res.Version = p.Version
+				}
+			}
+			results = append(results, res)
+			continue
+		}
+
+		// Lazily fetch the registry on the first actual install.
+		if registry == nil {
+			registry, err = m.registry.Fetch(ctx, false)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch registry: %w", err)
+			}
+		}
+
+		info, err := registry.GetPlugin(action.Requirement.Name)
+		if err != nil {
+			res.Err = err
+			results = append(results, res)
+			continue
+		}
+		if !action.Requirement.Satisfies(info.Version) {
+			res.Err = fmt.Errorf("registry offers %s %s, which does not satisfy %s",
+				info.Name, info.Version, action.Requirement.Raw)
+			results = append(results, res)
+			continue
+		}
+
+		if err := m.Install(ctx, action.Requirement.Name); err != nil {
+			res.Err = err
+			results = append(results, res)
+			continue
+		}
+		res.Installed = true
+		res.Version = info.Version
+		results = append(results, res)
+	}
+
+	return results, nil
+}
+
 // Uninstall removes a plugin.
 func (m *Manager) Uninstall(ctx context.Context, name string) error {
 	manifest, err := m.loadManifest()

--- a/internal/plugin/manager/required.go
+++ b/internal/plugin/manager/required.go
@@ -1,0 +1,117 @@
+// Package manager provides plugin management functionality for Relicta.
+package manager
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// Requirement is one entry of plugins_security.required: a plugin name with
+// an optional semver constraint ("github", "github@^2.0", "slack@>=1.2").
+type Requirement struct {
+	// Name of the plugin.
+	Name string
+	// Constraint is the parsed semver constraint; nil means "any version".
+	Constraint *semver.Constraints
+	// Raw is the original spec string, kept for error messages.
+	Raw string
+}
+
+// ParseRequirement parses a "name[@constraint]" spec.
+func ParseRequirement(spec string) (Requirement, error) {
+	raw := strings.TrimSpace(spec)
+	if raw == "" {
+		return Requirement{}, fmt.Errorf("empty plugin requirement")
+	}
+
+	name, constraintStr, found := strings.Cut(raw, "@")
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return Requirement{}, fmt.Errorf("requirement %q: missing plugin name", raw)
+	}
+
+	req := Requirement{Name: name, Raw: raw}
+	if found {
+		c, err := semver.NewConstraint(strings.TrimSpace(constraintStr))
+		if err != nil {
+			return Requirement{}, fmt.Errorf("requirement %q: invalid version constraint: %w", raw, err)
+		}
+		req.Constraint = c
+	}
+	return req, nil
+}
+
+// ParseRequirements parses all specs, collecting every error so the operator
+// sees the full list at once.
+func ParseRequirements(specs []string) ([]Requirement, error) {
+	var (
+		reqs []Requirement
+		errs []string
+	)
+	for _, s := range specs {
+		r, err := ParseRequirement(s)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+		reqs = append(reqs, r)
+	}
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("invalid plugin requirements:\n  %s", strings.Join(errs, "\n  "))
+	}
+	return reqs, nil
+}
+
+// Satisfies reports whether the given installed version meets the requirement.
+// Versions that do not parse as semver never satisfy a constraint.
+func (r Requirement) Satisfies(version string) bool {
+	if r.Constraint == nil {
+		return version != ""
+	}
+	v, err := semver.NewVersion(strings.TrimPrefix(version, "v"))
+	if err != nil {
+		return false
+	}
+	return r.Constraint.Check(v)
+}
+
+// RequiredAction describes what to do for one requirement.
+type RequiredAction struct {
+	Requirement Requirement
+	// Install is true when the plugin must be (re)installed.
+	Install bool
+	// Reason explains the action ("not installed", "installed 1.0.0 does
+	// not satisfy ^2.0", "satisfied").
+	Reason string
+}
+
+// ResolveRequired computes the install actions for the required set, given
+// the currently installed plugins. Registry availability and version
+// matching are checked by the installer at execution time; resolution here
+// only decides whether the installed state already satisfies each spec.
+func ResolveRequired(reqs []Requirement, installed []InstalledPlugin) []RequiredAction {
+	byName := make(map[string]InstalledPlugin, len(installed))
+	for _, p := range installed {
+		byName[p.Name] = p
+	}
+
+	actions := make([]RequiredAction, 0, len(reqs))
+	for _, r := range reqs {
+		cur, ok := byName[r.Name]
+		switch {
+		case !ok:
+			actions = append(actions, RequiredAction{Requirement: r, Install: true, Reason: "not installed"})
+		case !r.Satisfies(cur.Version):
+			actions = append(actions, RequiredAction{
+				Requirement: r,
+				Install:     true,
+				Reason:      fmt.Sprintf("installed %s does not satisfy %s", cur.Version, r.Raw),
+			})
+		default:
+			actions = append(actions, RequiredAction{Requirement: r, Install: false, Reason: "satisfied"})
+		}
+	}
+	return actions
+}

--- a/internal/plugin/manager/required_test.go
+++ b/internal/plugin/manager/required_test.go
@@ -1,8 +1,11 @@
 package manager
 
 import (
+	"context"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseRequirement(t *testing.T) {
@@ -89,5 +92,74 @@ func TestResolveRequired(t *testing.T) {
 	}
 	if !got["jira"] {
 		t.Error("jira v2.9.0 violates >=3.0 — install required")
+	}
+}
+
+func TestManager_InstallRequired(t *testing.T) {
+	pluginDir := t.TempDir()
+	configDir := t.TempDir()
+	cacheDir := t.TempDir()
+
+	writeRegistryConfig(t, configDir, []RegistryEntry{
+		{Name: OfficialRegistryName, URL: OfficialRegistryURL, Priority: 1000, Enabled: false},
+		{Name: "local", URL: "https://example.com/registry.yaml", Priority: 10, Enabled: true},
+	})
+	writeRegistryCache(t, cacheDir, "local", Registry{
+		Version: "1.0",
+		Plugins: []PluginInfo{
+			{Name: "jira", Version: "v2.9.0"}, // violates >=3.0 below
+		},
+		UpdatedAt: time.Now(),
+	})
+
+	mgr := &Manager{
+		registry:     NewRegistryService(configDir, cacheDir),
+		installer:    NewInstaller(pluginDir),
+		pluginDir:    pluginDir,
+		cacheDir:     cacheDir,
+		manifestPath: filepath.Join(pluginDir, ManifestFile),
+	}
+
+	// Pre-install github 2.0.3 via the manifest.
+	manifest := &Manifest{
+		Version:   "1.0",
+		Installed: []InstalledPlugin{{Name: "github", Version: "v2.0.3"}},
+	}
+	if err := mgr.saveManifest(manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := mgr.InstallRequired(context.Background(), []string{
+		"github@^2.0", // satisfied — skipped, no registry needed
+		"missing",     // not in registry — per-spec error
+		"jira@>=3.0",  // registry offers 2.9.0 — constraint error
+	})
+	if err != nil {
+		t.Fatalf("InstallRequired: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	bySpec := map[string]RequiredResult{}
+	for _, r := range results {
+		bySpec[r.Spec] = r
+	}
+
+	if r := bySpec["github@^2.0"]; !r.Skipped || r.Err != nil || r.Version != "v2.0.3" {
+		t.Errorf("github: %+v", r)
+	}
+	if r := bySpec["missing"]; r.Err == nil {
+		t.Errorf("missing plugin must error: %+v", r)
+	}
+	if r := bySpec["jira@>=3.0"]; r.Err == nil || !strings.Contains(r.Err.Error(), "does not satisfy") {
+		t.Errorf("constraint violation must error with offered version: %+v", r)
+	}
+}
+
+func TestManager_InstallRequired_InvalidSpecs(t *testing.T) {
+	mgr := &Manager{manifestPath: filepath.Join(t.TempDir(), ManifestFile)}
+	if _, err := mgr.InstallRequired(context.Background(), []string{"@broken"}); err == nil {
+		t.Fatal("invalid specs must fail before any resolution")
 	}
 }

--- a/internal/plugin/manager/required_test.go
+++ b/internal/plugin/manager/required_test.go
@@ -1,0 +1,93 @@
+package manager
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseRequirement(t *testing.T) {
+	cases := []struct {
+		spec       string
+		wantName   string
+		constraint bool
+		wantErr    bool
+	}{
+		{"github", "github", false, false},
+		{"github@^2.0", "github", true, false},
+		{" slack@>=1.2 ", "slack", true, false},
+		{"@^1.0", "", false, true},
+		{"", "", false, true},
+		{"jira@not-a-constraint!", "", false, true},
+	}
+	for _, c := range cases {
+		r, err := ParseRequirement(c.spec)
+		if c.wantErr != (err != nil) {
+			t.Errorf("ParseRequirement(%q) err = %v", c.spec, err)
+			continue
+		}
+		if err != nil {
+			continue
+		}
+		if r.Name != c.wantName || (r.Constraint != nil) != c.constraint {
+			t.Errorf("ParseRequirement(%q) = %+v", c.spec, r)
+		}
+	}
+}
+
+func TestParseRequirementsCollectsAllErrors(t *testing.T) {
+	_, err := ParseRequirements([]string{"good", "@bad", "also@bad!"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "@bad") || !strings.Contains(err.Error(), "also@bad!") {
+		t.Errorf("error must list every bad spec: %v", err)
+	}
+}
+
+func TestRequirementSatisfies(t *testing.T) {
+	anyVersion, _ := ParseRequirement("github")
+	if !anyVersion.Satisfies("v2.0.3") {
+		t.Error("unconstrained requirement satisfied by any installed version")
+	}
+	if anyVersion.Satisfies("") {
+		t.Error("empty version never satisfies")
+	}
+
+	caret, _ := ParseRequirement("github@^2.0")
+	if !caret.Satisfies("v2.5.1") {
+		t.Error("2.5.1 satisfies ^2.0")
+	}
+	if caret.Satisfies("v3.0.0") {
+		t.Error("3.0.0 does not satisfy ^2.0")
+	}
+	if caret.Satisfies("garbage") {
+		t.Error("non-semver versions never satisfy constraints")
+	}
+}
+
+func TestResolveRequired(t *testing.T) {
+	reqs, err := ParseRequirements([]string{"github@^2.0", "slack", "jira@>=3.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	installed := []InstalledPlugin{
+		{Name: "github", Version: "v2.0.3"},
+		{Name: "jira", Version: "v2.9.0"},
+	}
+
+	actions := ResolveRequired(reqs, installed)
+	got := map[string]bool{}
+	for _, a := range actions {
+		got[a.Requirement.Name] = a.Install
+	}
+
+	if got["github"] {
+		t.Error("github v2.0.3 satisfies ^2.0 — no install")
+	}
+	if !got["slack"] {
+		t.Error("slack not installed — install required")
+	}
+	if !got["jira"] {
+		t.Error("jira v2.9.0 violates >=3.0 — install required")
+	}
+}


### PR DESCRIPTION
Phase 3 first increment (follows #139, parallel to #141 — no file overlap).

## What

`.relicta.yaml`:

```yaml
plugin_security:
  required:
    - github@^2.0
    - slack
```

`relicta plugin install` (no args) resolves the set:

- `name@constraint` semver specs (Masterminds), parse errors reported all at once
- already-satisfied requirements skipped (`installed 2.0.3 satisfies ^2.0`)
- registry version must satisfy the constraint, else the spec fails with the offered version in the message
- per-spec failures collected; exit non-zero with a count, but every spec is attempted

## Not in this increment

- `auto_install` before release commands (field reserved)
- content-addressed artifact cache
- index-based multi-version resolution (single-version legacy registry for now; the v2 index from #139 enables proper resolution next)

## Verification

New tests: requirement parsing/constraint matching/resolution; CLI + plugin + config suites green; lint + nox clean.