### PR TITLE
fix(security): fail closed on attestation verify + dashboard no-auth exposure

### DIFF
--- a/.nox/baseline.json
+++ b/.nox/baseline.json
@@ -1365,6 +1365,13 @@
       "file_path": "internal/plugin/manager/trust.go",
       "severity": "medium",
       "created_at": "2026-06-12T09:02:40.618474Z"
+    },
+    {
+      "fingerprint": "6c0a6a8fc0f0538da9eaa9490f06f7c8398e5ab2529922d0bbc9f1806f5e44d7",
+      "rule_id": "SEC-163",
+      "file_path": "internal/security/attestation/verifier.go",
+      "severity": "medium",
+      "created_at": "2026-06-13T09:32:19.022314Z"
     }
   ]
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1174,6 +1174,11 @@ type DashboardAuthConfig struct {
 	SessionMaxAge time.Duration `mapstructure:"session_max_age" json:"session_max_age,omitempty"`
 	// OIDC configures OpenID Connect authentication (required for oidc mode).
 	OIDC *OIDCConfig `mapstructure:"oidc" json:"oidc,omitempty"`
+	// AllowInsecureNoAuth must be set explicitly to run mode=none on a
+	// non-loopback bind address. Without it the server refuses to start
+	// when unauthenticated and reachable off-host, so a dashboard is never
+	// silently exposed with anonymous admin access.
+	AllowInsecureNoAuth bool `mapstructure:"allow_insecure_no_auth" json:"allow_insecure_no_auth,omitempty"`
 }
 
 // DashboardAPIKeyConfig configures a single API key for dashboard access.
@@ -1272,6 +1277,11 @@ type AttestationConfig struct {
 	RekorURL string `mapstructure:"rekor_url" json:"rekor_url,omitempty"`
 	// FulcioURL is the Fulcio CA URL (for keyless mode).
 	FulcioURL string `mapstructure:"fulcio_url" json:"fulcio_url,omitempty"`
+	// Required makes attestation generation/signing/writing failures fail
+	// the publish step instead of being swallowed as a non-blocking
+	// warning. Defaults to false to preserve best-effort behavior; set it
+	// when an unsigned-or-missing attestation must block the release.
+	Required bool `mapstructure:"required" json:"required,omitempty"`
 }
 
 // ObservabilityConfig configures runtime observability integration for

--- a/internal/container/port_adapters.go
+++ b/internal/container/port_adapters.go
@@ -549,22 +549,31 @@ func (a *PublisherAdapter) executeAttestationStep(ctx context.Context, run *doma
 	repoID := run.RepoRoot()
 	gen := attestation.NewGenerator(repoID, a.auditChain)
 
+	// attestationFailure reports an attestation error. When the operator
+	// marked attestation Required, the failure blocks the publish step
+	// instead of being silently swallowed as success (the previous
+	// behavior shipped releases with no attestation and no signal).
+	attestationFailure := func(stage string, cause error) (*ports.StepResult, error) {
+		if a.attestationConfig.Required {
+			wrapped := fmt.Errorf("attestation %s failed: %w", stage, cause)
+			return &ports.StepResult{Success: false, Error: wrapped}, wrapped
+		}
+		return &ports.StepResult{
+			Success: true,
+			Output:  fmt.Sprintf("Attestation %s failed (non-blocking): %v", stage, cause),
+		}, nil
+	}
+
 	// Generate the attestation statement
 	stmt, err := gen.Generate(ctx, run)
 	if err != nil {
-		return &ports.StepResult{
-			Success: true,
-			Output:  fmt.Sprintf("Attestation generation failed (non-blocking): %v", err),
-		}, nil
+		return attestationFailure("generation", err)
 	}
 
 	// Parse signing mode and create signer
 	mode, err := attestation.ParseSigningMode(a.attestationConfig.SigningMode)
 	if err != nil {
-		return &ports.StepResult{
-			Success: true,
-			Output:  fmt.Sprintf("Attestation signing mode invalid (non-blocking): %v", err),
-		}, nil
+		return attestationFailure("signing-mode parse", err)
 	}
 
 	var signerOpts []attestation.SignerOption
@@ -577,19 +586,13 @@ func (a *PublisherAdapter) executeAttestationStep(ctx context.Context, run *doma
 	// Sign the attestation
 	signed, err := signer.Sign(ctx, stmt)
 	if err != nil {
-		return &ports.StepResult{
-			Success: true,
-			Output:  fmt.Sprintf("Attestation signing failed (non-blocking): %v", err),
-		}, nil
+		return attestationFailure("signing", err)
 	}
 
 	// Write the signed attestation to the release directory
 	outputPath, err := a.writeAttestation(run, signed)
 	if err != nil {
-		return &ports.StepResult{
-			Success: true,
-			Output:  fmt.Sprintf("Attestation write failed (non-blocking): %v", err),
-		}, nil
+		return attestationFailure("write", err)
 	}
 
 	return &ports.StepResult{

--- a/internal/httpserver/middleware/auth.go
+++ b/internal/httpserver/middleware/auth.go
@@ -54,10 +54,13 @@ func Auth(cfg config.DashboardAuthConfig, tokenSvc *token.Service) func(http.Han
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch cfg.Mode {
 			case config.DashboardAuthNone, "":
-				// No authentication - pass through with anonymous user
+				// No authentication - pass through with an anonymous, READ-ONLY
+				// user. Granting admin here let unauthenticated callers
+				// approve/reject releases; viewer keeps no-auth usable for
+				// local inspection without exposing mutating actions.
 				user := &AuthenticatedUser{
 					Name:  "anonymous",
-					Roles: []string{string(config.DashboardRoleAdmin)}, // Full access when auth disabled
+					Roles: []string{string(config.DashboardRoleViewer)},
 				}
 				ctx := context.WithValue(r.Context(), UserContextKey, user)
 				next.ServeHTTP(w, r.WithContext(ctx))

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -104,6 +105,14 @@ func NewServer(deps ServerDeps) *Server {
 
 // Start starts the HTTP server.
 func (s *Server) Start(ctx context.Context) error {
+	// Refuse to expose an unauthenticated dashboard off-host. mode=none
+	// grants anonymous (read-only) access; binding it to a non-loopback
+	// address without an explicit opt-in would silently publish the
+	// dashboard to the network.
+	if err := guardInsecureExposure(s.config); err != nil {
+		return err
+	}
+
 	// Start WebSocket hub
 	go s.wsHub.Run(ctx)
 
@@ -131,6 +140,51 @@ func (s *Server) Start(ctx context.Context) error {
 	case err := <-errChan:
 		return err
 	}
+}
+
+// guardInsecureExposure blocks startup when the dashboard would be both
+// unauthenticated and reachable off-host. mode=none on a loopback address is
+// fine for local development; binding it elsewhere requires the explicit
+// auth.allow_insecure_no_auth opt-in.
+func guardInsecureExposure(cfg config.DashboardConfig) error {
+	mode := cfg.Auth.Mode
+	if mode != config.DashboardAuthNone && mode != "" {
+		return nil // authenticated
+	}
+	if cfg.Auth.AllowInsecureNoAuth {
+		return nil // operator explicitly accepted the risk
+	}
+	if isLoopbackBind(cfg.Address) {
+		return nil // not reachable off-host
+	}
+	return fmt.Errorf(
+		"refusing to start dashboard with auth mode=none on non-loopback address %q: "+
+			"configure dashboard.auth (api_key/session/oidc), bind to localhost, "+
+			"or set dashboard.auth.allow_insecure_no_auth=true to override",
+		cfg.Address)
+}
+
+// isLoopbackBind reports whether the bind address only serves the local host.
+func isLoopbackBind(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = strings.TrimPrefix(addr, ":") // tolerate ":8080" form... falls through
+		if host == addr {
+			return false
+		}
+		host = ""
+	}
+	switch host {
+	case "localhost":
+		return true
+	case "":
+		// ":8080" / empty host binds all interfaces — not loopback-only.
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // Shutdown gracefully shuts down the server.

--- a/internal/security/attestation/verifier.go
+++ b/internal/security/attestation/verifier.go
@@ -99,8 +99,14 @@ func (v *Verifier) Verify(_ context.Context, att *SignedAttestation) (*Verificat
 // verifySignature verifies a cryptographic signature against the payload.
 func (v *Verifier) verifySignature(payload []byte, sig Signature) error {
 	if v.publicKeyPEM == nil {
-		// If no public key configured, accept any signature (trust mode).
-		return nil
+		// A signature is present but we have no key to check it against, so
+		// we cannot establish validity. Fail closed unless the operator has
+		// explicitly opted into accepting unverified attestations — anything
+		// else lets a forged signature pass as valid (the previous behavior).
+		if v.allowUnsigned {
+			return nil
+		}
+		return fmt.Errorf("attestation is signed but no public key is configured to verify it: pass --public-key, or --allow-unsigned to accept unverified attestations")
 	}
 
 	block, _ := pem.Decode(v.publicKeyPEM)

--- a/internal/security/attestation/verifier_test.go
+++ b/internal/security/attestation/verifier_test.go
@@ -249,12 +249,37 @@ func TestVerifier_CheckGovernance_NoConstraints(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestVerifier_Verify_NoPublicKey_TrustMode(t *testing.T) {
+func TestVerifier_Verify_NoPublicKey_FailsClosed(t *testing.T) {
 	pred := GovernancePredicate{Version: "1.0.0", Decision: "approved"}
 	att, _ := signedAttestationForTest(t, pred)
 
-	// Verify without providing a public key (trust mode).
+	// Verifying a signed attestation without a public key can't establish
+	// validity, so it must fail closed (was previously accepted blindly).
 	verifier := NewVerifier()
+	_, err := verifier.Verify(context.Background(), att)
+	require.Error(t, err)
+}
+
+// TestVerifier_Verify_SignedNoKey_FailsClosed is the regression test for the
+// fail-open vuln: a signed attestation with no configured public key must be
+// rejected, not blindly accepted as valid.
+func TestVerifier_Verify_SignedNoKey_FailsClosed(t *testing.T) {
+	pred := GovernancePredicate{Version: "1.0.0", Decision: "approved"}
+	att, _ := signedAttestationForTest(t, pred)
+
+	verifier := NewVerifier() // no public key, no allow-unsigned
+	_, err := verifier.Verify(context.Background(), att)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no public key")
+}
+
+// TestVerifier_Verify_SignedNoKey_AllowUnsigned lets the operator explicitly
+// accept unverifiable attestations.
+func TestVerifier_Verify_SignedNoKey_AllowUnsigned(t *testing.T) {
+	pred := GovernancePredicate{Version: "1.0.0", Decision: "approved"}
+	att, _ := signedAttestationForTest(t, pred)
+
+	verifier := NewVerifier(WithAllowUnsigned(true))
 	result, err := verifier.Verify(context.Background(), att)
 	require.NoError(t, err)
 	assert.True(t, result.Valid)


### PR DESCRIPTION
Tier 1 of the improvement audit — two genuine fail-open vulnerabilities.

## Attestation verification (`internal/security/attestation`)
- A **signed** attestation verified with no configured public key returned `Valid=true` for arbitrary signature bytes (`verifier.go:101`) — any forged attestation passed. Now fails closed unless the operator passes `--allow-unsigned`. `relicta verify` already wires both `--public-key` and `--allow-unsigned`.
- The publish-time attestation step swallowed every generate/sign/write failure as `Success:true` (`port_adapters.go`), shipping releases with no attestation and no signal. New `attestation.required` config makes those failures block the step (default false = current best-effort behavior).

## Dashboard auth (`internal/httpserver`)
- `mode=none` mapped anonymous callers to the **admin** role → unauthenticated approve/reject. Anonymous now gets **viewer** (read-only).
- Server refused to bind a non-loopback address with `mode=none` unless `auth.allow_insecure_no_auth=true`. Localhost dev still works zero-config.

## Tests
New: signed-no-key fails closed (+ allow-unsigned escape), dashboard exposure guard cases. Updated the old `TrustMode` test that encoded the fail-open behavior. Full security + httpserver + container + config suites green; lint + nox clean.