### PR TITLE
feat(plugin): wire trust-policy verification into plugin install (ADR-008)

### DIFF
--- a/internal/cli/plugin_manager_injection.go
+++ b/internal/cli/plugin_manager_injection.go
@@ -23,5 +23,21 @@ type pluginManager interface {
 }
 
 var newPluginManager = func() (pluginManager, error) {
-	return manager.NewManager()
+	mgr, err := manager.NewManager()
+	if err != nil {
+		return nil, err
+	}
+	// Apply the configured plugin trust policy (ADR-008). Defaults to
+	// permissive when unset so the legacy unsigned registry keeps working;
+	// operators opt into signature enforcement via plugin_security.trust_policy.
+	if cfg != nil {
+		policy := cfg.PluginSecurity.TrustPolicy
+		if policy == "" {
+			policy = string(manager.TrustPermissive)
+		}
+		if err := mgr.SetTrustPolicy(policy, cfg.PluginSecurity.TrustKey); err != nil {
+			return nil, err
+		}
+	}
+	return mgr, nil
 }

--- a/internal/plugin/manager/installer.go
+++ b/internal/plugin/manager/installer.go
@@ -24,6 +24,10 @@ const MaxPluginFileSize = 100 * 1024 * 1024
 type Installer struct {
 	httpClient *http.Client
 	pluginDir  string
+	// verifier applies the trust policy (digest + optional Cosign keyless
+	// verification) to the downloaded archive. When nil the installer falls
+	// back to the legacy bare-checksum check.
+	verifier *Verifier
 }
 
 // NewInstaller creates a new plugin installer.
@@ -34,6 +38,36 @@ func NewInstaller(pluginDir string) *Installer {
 		},
 		pluginDir: pluginDir,
 	}
+}
+
+// SetVerifier attaches a trust-policy verifier used to validate downloaded
+// archives before extraction.
+func (i *Installer) SetVerifier(v *Verifier) {
+	i.verifier = v
+}
+
+// artifactForVerification bridges a legacy registry PluginInfo into the
+// IndexArtifact shape the trust Verifier consumes. The legacy registry
+// carries only per-platform checksums (no Cosign metadata), so under the
+// default/enterprise policies these artifacts fail closed until the v2
+// index supplies signatures — which is the intended migration pressure.
+func artifactForVerification(p *PluginInfo) IndexArtifact {
+	goos, goarch := splitPlatform(GetCurrentPlatform())
+	digest := p.GetChecksum()
+	if digest != "" {
+		digest = "sha256:" + digest
+	}
+	return IndexArtifact{OS: goos, Arch: goarch, Digest: digest}
+}
+
+// splitPlatform converts a "darwin_aarch64" platform key into index
+// (os, arch) form ("darwin", "arm64").
+func splitPlatform(key string) (string, string) {
+	goos, goarch, ok := platformKeyToOSArch(key)
+	if !ok {
+		return key, ""
+	}
+	return goos, goarch
 }
 
 // Install downloads and installs a plugin binary.
@@ -66,9 +100,16 @@ func (i *Installer) Install(ctx context.Context, pluginInfo PluginInfo) (*Instal
 		return nil, fmt.Errorf("failed to close temp file: %w", err)
 	}
 
-	// Verify archive checksum BEFORE extraction (security: prevent installing tampered archives)
-	expectedChecksum := pluginInfo.GetChecksum()
-	if expectedChecksum != "" {
+	// Verify the downloaded archive BEFORE extraction. When a trust-policy
+	// verifier is configured it owns verification (digest + Cosign keyless
+	// under the active policy, failing closed); otherwise fall back to the
+	// legacy bare-checksum comparison.
+	if i.verifier != nil {
+		artifact := artifactForVerification(&pluginInfo)
+		if err := i.verifier.VerifyArtifact(ctx, tmpFile.Name(), artifact); err != nil {
+			return nil, fmt.Errorf("plugin %s failed trust verification: %w", pluginInfo.Name, err)
+		}
+	} else if expectedChecksum := pluginInfo.GetChecksum(); expectedChecksum != "" {
 		archiveFile, err := os.Open(tmpFile.Name())
 		if err != nil {
 			return nil, fmt.Errorf("failed to open archive for checksum verification: %w", err)

--- a/internal/plugin/manager/manager.go
+++ b/internal/plugin/manager/manager.go
@@ -62,6 +62,20 @@ func NewManager() (*Manager, error) {
 	}, nil
 }
 
+// SetTrustPolicy configures how downloaded plugin archives are verified at
+// install time. keyPath is the operator public key required by the
+// enterprise policy. An empty/invalid policy returns an error.
+func (m *Manager) SetTrustPolicy(policy string, keyPath string) error {
+	p, err := ParseTrustPolicy(policy)
+	if err != nil {
+		return err
+	}
+	v := NewVerifier(p)
+	v.KeyPath = keyPath
+	m.installer.SetVerifier(v)
+	return nil
+}
+
 // ListAvailable returns all plugins available in the registry.
 func (m *Manager) ListAvailable(ctx context.Context, forceRefresh bool) ([]PluginListEntry, error) {
 	registry, err := m.registry.Fetch(ctx, forceRefresh)

--- a/internal/plugin/manager/trust_test.go
+++ b/internal/plugin/manager/trust_test.go
@@ -124,3 +124,42 @@ func TestVerifyArtifact_EnterpriseRequiresKey(t *testing.T) {
 		t.Fatalf("enterprise without key must fail, got %v", err)
 	}
 }
+
+func TestInstaller_SetVerifier_DigestPathThroughVerifier(t *testing.T) {
+	// With a permissive verifier attached, the installer verifies the
+	// archive digest through the trust path instead of the legacy checksum
+	// branch. artifactForVerification bridges PluginInfo → IndexArtifact.
+	p := &PluginInfo{
+		Name:      "demo",
+		Checksums: map[string]string{GetCurrentPlatform(): "abc123"},
+	}
+	art := artifactForVerification(p)
+	if art.Digest != "sha256:abc123" {
+		t.Errorf("digest bridge = %q, want sha256:abc123", art.Digest)
+	}
+	goos, _ := splitPlatform(GetCurrentPlatform())
+	if art.OS != goos {
+		t.Errorf("os = %q, want %q", art.OS, goos)
+	}
+}
+
+func TestInstaller_DefaultPolicyFailsClosedOnLegacyEntry(t *testing.T) {
+	// A legacy registry entry carries no Cosign metadata, so the default
+	// (signature-requiring) policy must refuse it — the migration pressure
+	// toward signed plugins.
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "a.tar.gz")
+	if err := os.WriteFile(archive, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256([]byte("data"))
+
+	inst := NewInstaller(dir)
+	inst.SetVerifier(NewVerifier(TrustDefault))
+
+	art := IndexArtifact{Digest: "sha256:" + hex.EncodeToString(sum[:])}
+	err := inst.verifier.VerifyArtifact(context.Background(), archive, art)
+	if err == nil || !strings.Contains(err.Error(), "Cosign keyless signature") {
+		t.Fatalf("default policy must reject unsigned legacy artifact, got %v", err)
+	}
+}


### PR DESCRIPTION
Tier 2 of the audit. The ADR-008 `Verifier` (digest + Cosign keyless, fail-closed under default/enterprise) shipped in #139 with **zero callers** — `Manager.Install` was checksum-only and skipped even that when a registry entry had no checksum. The advertised plugin signature verification never actually ran.

## Change
- `Installer.SetVerifier` + `Manager.SetTrustPolicy(policy, keyPath)`
- Install routes the pre-extraction archive check through the Verifier when a policy is set
- CLI wires it from `plugin_security.trust_policy` / `trust_key` (defaults to **permissive** so the legacy unsigned registry keeps working)
- `artifactForVerification` bridges legacy `PluginInfo` checksums → `IndexArtifact`

## Behavior
- **permissive** (default): digest verification through the unified path (same guarantee as before, no longer a dead bare-checksum branch)
- **default/enterprise**: a legacy entry with no Cosign metadata **fails closed** — the migration pressure toward signed plugins. Once the v2 index carries cosign fields, `default` enforces signatures with no further wiring.

Tests: digest bridge, default-policy fail-closed on unsigned legacy entry. Plugin + CLI suites green, lint + nox clean.