### PR TITLE
fix(cli): enforce actor autonomy budget on publish/approve/rollback

### DIFF
--- a/internal/cli/actor_budget.go
+++ b/internal/cli/actor_budget.go
@@ -1,0 +1,66 @@
+// Package cli provides the command-line interface for Relicta.
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/relicta-tech/relicta/v4/internal/cgp/policy"
+)
+
+// enforceActorBudget gates a privileged CLI operation (publish/approve/
+// rollback) against the per-actor autonomy budget — the same control the MCP
+// surface applies. Before this, the CLI path skipped budget enforcement
+// entirely, so an agent or CI actor could drive high-risk releases the
+// autonomy slider was meant to block.
+//
+// Budgets load from governance.actor_budget_path when set; otherwise
+// ResolveBudget supplies safe defaults (humans permissive, agents/CI
+// restrictive). tool is the logical operation name ("publish", "approve",
+// "rollback"); riskScore is the CGP risk of the change being acted upon.
+func enforceActorBudget(tool string, riskScore float64) error {
+	var set *policy.ActorBudgetSet
+	if cfg != nil && cfg.Governance.ActorBudgetPath != "" {
+		loaded, err := policy.LoadActorBudgets(cfg.Governance.ActorBudgetPath)
+		if err != nil {
+			return fmt.Errorf("failed to load actor budgets from %s: %w", cfg.Governance.ActorBudgetPath, err)
+		}
+		set = loaded
+	}
+
+	actor := createCGPActor()
+	budget := policy.ResolveBudget(set, actor.Kind.String(), actor.ID)
+
+	decision := budget.Evaluate(policy.Operation{
+		Tool:        tool,
+		BlastRadius: blastRadiusForRisk(riskScore),
+		RiskScore:   riskScore,
+	})
+	if decision.Allowed {
+		return nil
+	}
+
+	var msgs []string
+	for _, v := range decision.Violations {
+		msgs = append(msgs, v.Message)
+	}
+	return fmt.Errorf("operation %q denied by autonomy budget for actor %s: %s",
+		tool, actor.ID, strings.Join(msgs, "; "))
+}
+
+// blastRadiusForRisk maps a risk score to a blast-radius category, mirroring
+// the MCP mapping so both surfaces gate identically.
+func blastRadiusForRisk(risk float64) policy.BlastRadius {
+	switch {
+	case risk >= 0.8:
+		return policy.BlastRadiusCritical
+	case risk >= 0.6:
+		return policy.BlastRadiusHigh
+	case risk >= 0.4:
+		return policy.BlastRadiusMedium
+	case risk > 0:
+		return policy.BlastRadiusLow
+	default:
+		return policy.BlastRadiusNone
+	}
+}

--- a/internal/cli/actor_budget_test.go
+++ b/internal/cli/actor_budget_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/relicta-tech/relicta/v4/internal/config"
+)
+
+func withEnv(t *testing.T, kv map[string]string) {
+	t.Helper()
+	for k, v := range kv {
+		old, had := os.LookupEnv(k)
+		_ = os.Setenv(k, v)
+		t.Cleanup(func() {
+			if had {
+				_ = os.Setenv(k, old)
+			} else {
+				_ = os.Unsetenv(k)
+			}
+		})
+	}
+}
+
+func TestEnforceActorBudget_HumanPermissiveByDefault(t *testing.T) {
+	origCfg := cfg
+	t.Cleanup(func() { cfg = origCfg })
+	cfg = config.DefaultConfig()
+
+	// Clear CI markers so the actor resolves as human.
+	withEnv(t, map[string]string{
+		"CI": "", "GITHUB_ACTIONS": "", "GITLAB_CI": "", "JENKINS_URL": "",
+		"USER": "alice", "GITHUB_ACTOR": "",
+	})
+
+	if err := enforceActorBudget("publish", 0.95); err != nil {
+		t.Fatalf("human should be permitted a high-risk publish by default: %v", err)
+	}
+}
+
+func TestEnforceActorBudget_CIRestrictedOnHighRisk(t *testing.T) {
+	origCfg := cfg
+	t.Cleanup(func() { cfg = origCfg })
+	cfg = config.DefaultConfig()
+
+	// GITHUB_ACTIONS marks the actor as CI → restrictive default budget.
+	withEnv(t, map[string]string{
+		"CI": "true", "GITHUB_ACTIONS": "true", "GITHUB_ACTOR": "ci-bot", "USER": "",
+	})
+
+	err := enforceActorBudget("publish", 0.95)
+	if err == nil {
+		t.Fatal("CI actor must be blocked from a critical-risk publish by the restrictive default budget")
+	}
+	if !strings.Contains(err.Error(), "autonomy budget") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnforceActorBudget_CIRequiresCosignEvenLowRisk(t *testing.T) {
+	origCfg := cfg
+	t.Cleanup(func() { cfg = origCfg })
+	cfg = config.DefaultConfig()
+
+	withEnv(t, map[string]string{
+		"CI": "true", "GITHUB_ACTIONS": "true", "GITHUB_ACTOR": "ci-bot", "USER": "",
+	})
+
+	// The restrictive default budget requires a human cosigner for
+	// publish/approve/rollback regardless of risk, so even a low-risk CI
+	// publish is blocked — agents/CI cannot self-authorize privileged ops.
+	if err := enforceActorBudget("publish", 0.1); err == nil {
+		t.Fatal("CI publish must require a cosigner under the restrictive default budget")
+	}
+}

--- a/internal/cli/approve.go
+++ b/internal/cli/approve.go
@@ -240,6 +240,12 @@ func executeApproval(ctx context.Context, app cliApp, rel *release.ReleaseRun, e
 func executeApprovalWithServices(ctx context.Context, app cliApp, repoPath string, rel *release.ReleaseRun, editedNotes *string) (*releaseapp.ApproveReleaseOutput, error) {
 	services := app.ReleaseServices()
 
+	// Enforce the per-actor autonomy budget before recording approval — the
+	// CLI previously skipped this gate that the MCP surface applies.
+	if err := enforceActorBudget("approve", rel.RiskScore()); err != nil {
+		return nil, err
+	}
+
 	// Handle edited notes separately - update the release before approval
 	if editedNotes != nil {
 		// Update notes on the release and save

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -173,6 +173,12 @@ func runPublishWithServices(ctx context.Context, app cliApp, repoPath, remoteURL
 		return fmt.Errorf("failed to load release: %w", err)
 	}
 
+	// Enforce the per-actor autonomy budget before publishing — the CLI
+	// previously skipped this gate that the MCP surface applies.
+	if err := enforceActorBudget("publish", run.RiskScore()); err != nil {
+		return err
+	}
+
 	nextVersion := run.VersionNext().String()
 
 	// Output JSON if requested

--- a/internal/cli/rollback.go
+++ b/internal/cli/rollback.go
@@ -61,6 +61,16 @@ func runRollback(cmd *cobra.Command, args []string) error {
 		printDryRunBanner()
 	}
 
+	// Enforce the per-actor autonomy budget for the real (non-dry-run)
+	// rollback. Rollback mutates production state and has no per-run risk
+	// score in hand, so it is gated as a critical-blast-radius operation —
+	// restrictive (agent/CI) budgets block it, permissive (human) allow.
+	if !effectiveDryRun {
+		if err := enforceActorBudget("rollback", 1.0); err != nil {
+			return err
+		}
+	}
+
 	// Initialize container
 	app, err := newContainerApp(ctx, cfg)
 	if err != nil {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -456,6 +456,11 @@ type GovernanceConfig struct {
 	RiskBudget *RiskBudgetConfig `mapstructure:"risk_budget" yaml:"risk_budget,omitempty" json:"risk_budget,omitempty"`
 	// FreezePeriods configures recurring time windows with restricted releases.
 	FreezePeriods []FreezePeriodConfig `mapstructure:"freeze_periods" yaml:"freeze_periods,omitempty" json:"freeze_periods,omitempty"`
+	// ActorBudgetPath is the path to the per-actor autonomy budget YAML.
+	// When set, CLI publish/approve/rollback enforce it (the autonomy
+	// slider). When empty, safe defaults apply: humans permissive,
+	// agents/CI restrictive.
+	ActorBudgetPath string `mapstructure:"actor_budget_path" json:"actor_budget_path,omitempty"`
 }
 
 // RiskBudgetConfig configures cumulative risk budget limits.


### PR DESCRIPTION
Tier 2 of the audit. The CLI privileged commands **never called `ResolveBudget`** — only the MCP surface enforced the autonomy slider. The loader docstring explicitly names `CLI publish/approve/rollback` as enforcement points, but the calls were missing, so an agent or CI actor could drive high-risk releases the budget was meant to block.

## Change
- `enforceActorBudget(tool, riskScore)` mirrors MCP's `checkBudget`: resolves the per-actor budget and evaluates blast radius + risk before the op
- Budgets load from new `governance.actor_budget_path` when set; otherwise `ResolveBudget` safe defaults apply (**human → permissive**, **agent/CI → restrictive**, which requires a human cosigner for publish/approve/rollback)
- Wired into `publish`, `approve`, and the non-dry-run `rollback` (gated as critical blast radius — rollback always mutates production)

## Behavior
| Actor | Operation | Result (default budget) |
|-------|-----------|-------------------------|
| human | publish risk 0.95 | allowed |
| CI | publish risk 0.95 | blocked |
| CI | publish risk 0.1 | blocked (cosign required) |

## Scope note
The related env-spoofable trust-level issue in `createCGPActor` (auto-trusting humans by `$USER`/`$GITHUB_ACTOR`) is **not** in this PR — changing trust semantics needs product input. Filed as a follow-up. This PR closes the documented budget-bypass.

Tests + lint + nox clean.