### PR TITLE
feat(logging): Bolt-backed slog, default WARN + fix --log-level propagation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,6 +140,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	go.klarlabs.de/bolt v1.5.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
@@ -149,6 +150,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/term v0.43.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -342,6 +342,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+go.klarlabs.de/bolt v1.5.2 h1:HB5p1tCZdizz7JpTSZYFPtp6R9oJB1LLVq74M9vH88w=
+go.klarlabs.de/bolt v1.5.2/go.mod h1:wz+vynyuDkLK2fgmoi0VvLurqvq4JcnMTMyDQpW+f7s=
 go.klarlabs.de/fortify v1.6.0 h1:Te2e3YKia0HBt1Abab3g4Rg6fcMTiiHEt2Vgrm2p6zk=
 go.klarlabs.de/fortify v1.6.0/go.mod h1:Yk9PNp6/0owR52NiqeUmk9pdScuUa6p4e8Hhz0T5vEo=
 go.klarlabs.de/mcp v1.15.0 h1:/2wtGgCYr7NhnJnHsetxgYzPKcry/y3onN0Xj9Tdoxg=

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,6 +4,8 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -16,6 +18,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/relicta-tech/relicta/v4/internal/config"
+	"github.com/relicta-tech/relicta/v4/internal/logging"
 	"github.com/relicta-tech/relicta/v4/internal/security"
 )
 
@@ -35,6 +38,7 @@ var (
 	noColor               bool
 	logLevel              string
 	logLevelAlias         string
+	logLevelExplicit      bool
 	modelFlag             string // --model flag for AI provider/model selection
 	ciMode                bool   // --ci flag for CI/CD pipeline mode (auto-approve, JSON output)
 	redactSecrets         bool   // --redact flag to mask sensitive data in output
@@ -104,6 +108,11 @@ releases in an AI-driven world.
 
 Get started with 'relicta init' to set up your project.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Record whether the operator explicitly set a log level on this
+		// invocation. configureSlog needs this to tell `--log-level info`
+		// (an explicit opt-in that must raise the slog floor) apart from the
+		// "info" default the flag carries when untouched.
+		logLevelExplicit = cmd.Flags().Changed("log-level") || cmd.Flags().Changed("log")
 		// Skip config loading for commands that don't need it
 		if cmd.Name() == "init" || cmd.Name() == "version" || cmd.Name() == "help" || cmd.Name() == "verify" || cmd.Name() == "report" || cmd.Name() == "plugin" || cmd.Name() == "mcp" || cmd.Name() == "policy" || cmd.Parent() != nil && (cmd.Parent().Name() == "plugin" || cmd.Parent().Name() == "mcp" || cmd.Parent().Name() == "policy") {
 			return nil
@@ -236,6 +245,13 @@ func applyGlobalFlags() {
 		cfg.Output.Verbose = true
 	}
 
+	// The --log-level flag is BindPFlag'd to the global viper, but cfg is built
+	// by config.NewLoader()'s own viper instance — so the binding never reaches
+	// cfg. Copy it explicitly when the operator set it (mirrors --verbose).
+	if logLevelExplicit {
+		cfg.Output.LogLevel = logLevel
+	}
+
 	if dryRun {
 		cfg.Workflow.DryRunByDefault = true
 	}
@@ -321,6 +337,36 @@ func configureLogLevel() {
 	}
 }
 
+// configureSlog routes operational slog logging through Bolt to stderr. The
+// default level is WARN so routine INFO chatter (e.g. "release services
+// initialized") never pollutes normal command output; --verbose or an
+// explicit --log-level raises it. This is the single hygiene swap point —
+// all slog.Default() call sites across the codebase inherit it.
+func configureSlog() {
+	// The operational slog firehose (release services, plugin loads, CGP
+	// evaluation traces) is internal plumbing, not command output. It stays at
+	// WARN by default so routine INFO chatter never pollutes stdout consumers,
+	// and rises only when the operator explicitly opts in via --log-level /
+	// --log, an output.log_level entry in the config file, or --verbose.
+	level := slog.LevelWarn
+	// Detect explicit opt-in without referencing rootCmd (avoids a package
+	// init cycle): the --log alias is non-empty, --log-level was moved off its
+	// "info" default, or the config file carries an output.log_level entry.
+	explicit := logLevelExplicit || logLevelAlias != "" || viper.InConfig("output.log_level")
+	if explicit {
+		level = logging.LevelFromString(cfg.Output.LogLevel)
+	}
+	if cfg.Output.Verbose {
+		level = slog.LevelDebug
+	}
+
+	out := io.Writer(os.Stderr)
+	if logFile != nil {
+		out = logFile
+	}
+	logging.Configure(level, out)
+}
+
 // configureLogFile sets up log file output if specified.
 func configureLogFile() error {
 	if cfg.Output.LogFile == "" {
@@ -354,8 +400,15 @@ func initConfig() error {
 	configureLoggerFormat()
 	configureLogLevel()
 
-	// Configure log file
-	return configureLogFile()
+	// Configure log file (may redirect output)
+	if err := configureLogFile(); err != nil {
+		return err
+	}
+
+	// Route operational slog logging through Bolt (stderr or log file).
+	// Done last so it picks up any --log-file redirect.
+	configureSlog()
+	return nil
 }
 
 // Cleanup closes any open resources. Should be called before program exit.

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,52 @@
+// Package logging configures the application's structured logger.
+//
+// Operational logs go through Bolt (go.klarlabs.de/bolt) — a zero-allocation
+// structured logger — exposed as an slog.Handler so existing slog call sites
+// are unchanged. All output is written to stderr, never stdout, so machine
+// consumers parsing a command's stdout (CI pipelines reading --json) never
+// see log noise. The default level is WARN: routine operational INFO lines
+// stay silent unless the operator opts into --verbose / --log-level.
+package logging
+
+import (
+	"io"
+	"log/slog"
+	"os"
+
+	"go.klarlabs.de/bolt"
+)
+
+// LevelFromString maps a config/flag level string to an slog.Level.
+// Unknown values fall back to the quiet default (WARN).
+func LevelFromString(level string) slog.Level {
+	switch level {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "error":
+		return slog.LevelError
+	case "warn", "":
+		return slog.LevelWarn
+	default:
+		return slog.LevelWarn
+	}
+}
+
+// New returns an slog.Logger backed by Bolt, writing to w at the given level.
+func New(w io.Writer, level slog.Level) *slog.Logger {
+	return slog.New(bolt.NewSlogHandler(w, &bolt.SlogHandlerOptions{Level: level}))
+}
+
+// Configure installs a Bolt-backed slog logger as the process default,
+// writing to stderr at the given level. Call once during startup after the
+// effective level is known. Passing a non-nil w overrides the stderr target
+// (used when logs are redirected to a file).
+func Configure(level slog.Level, w io.Writer) *slog.Logger {
+	if w == nil {
+		w = os.Stderr
+	}
+	l := New(w, level)
+	slog.SetDefault(l)
+	return l
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,75 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestLevelFromString(t *testing.T) {
+	cases := map[string]slog.Level{
+		"debug":   slog.LevelDebug,
+		"info":    slog.LevelInfo,
+		"warn":    slog.LevelWarn,
+		"error":   slog.LevelError,
+		"":        slog.LevelWarn, // quiet default
+		"bogus":   slog.LevelWarn, // unknown falls back to quiet default
+		"WARNING": slog.LevelWarn, // unrecognized casing falls back
+	}
+	for in, want := range cases {
+		if got := LevelFromString(in); got != want {
+			t.Errorf("LevelFromString(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestNewRespectsLevel(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(&buf, slog.LevelWarn)
+
+	l.Info("routine plumbing")
+	if buf.Len() != 0 {
+		t.Fatalf("INFO record leaked at WARN level: %q", buf.String())
+	}
+
+	l.Warn("something to surface")
+	if !strings.Contains(buf.String(), "something to surface") {
+		t.Fatalf("WARN record missing: %q", buf.String())
+	}
+}
+
+func TestNewEnabledThreshold(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(&buf, slog.LevelError)
+	if l.Handler().Enabled(context.Background(), slog.LevelWarn) {
+		t.Error("handler enabled WARN below ERROR threshold")
+	}
+	if !l.Handler().Enabled(context.Background(), slog.LevelError) {
+		t.Error("handler disabled ERROR at ERROR threshold")
+	}
+}
+
+func TestConfigureSetsDefault(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	var buf bytes.Buffer
+	returned := Configure(slog.LevelWarn, &buf)
+	if returned == nil {
+		t.Fatal("Configure returned nil logger")
+	}
+	if slog.Default() != returned {
+		t.Error("Configure did not install the logger as slog default")
+	}
+
+	slog.Info("noise")
+	if buf.Len() != 0 {
+		t.Errorf("INFO leaked through default logger at WARN: %q", buf.String())
+	}
+	slog.Error("real problem")
+	if !strings.Contains(buf.String(), "real problem") {
+		t.Errorf("ERROR missing from default logger: %q", buf.String())
+	}
+}


### PR DESCRIPTION
## What

Output-hygiene initiative (task #14): operational slog now flows through a **Bolt** (`go.klarlabs.de/bolt`) handler at **WARN by default**, written to **stderr**.

### Why
Routine INFO plumbing (`release services initialized`, plugin loads, CGP traces) was leaking into normal command output, polluting stdout for machine consumers (CI reading `--json`).

### Changes
- New `internal/logging` package: Bolt-backed `slog.Handler`, `LevelFromString`, `Configure`. One swap point — all 45 `slog.Default()` call sites inherit it.
- `configureSlog()` in `root.go`: WARN floor; raised only by explicit `--log-level` / `--log` / config `output.log_level` / `--verbose`.
- **Latent bug fix:** `--log-level` was `BindPFlag`'d to the *global* viper, but `cfg` is built by `config.NewLoader()`'s *own* viper instance — so the flag never reached `cfg.Output.LogLevel`. Now copied explicitly in `applyGlobalFlags` (mirrors `--verbose`). Fixes the level for both the legacy charmbracelet logger and the new slog floor.
- Tests for the logging package.

### Verification
| invocation | resolved level | `release services` INFO on stderr |
|---|---|---|
| (default) | WARN | hidden |
| `--log-level warn` | WARN | hidden |
| `--log-level info` | INFO | shown |
| `--log-level error` | ERROR | hidden |
| `--verbose` | DEBUG | shown |

stdout is clean of log JSON in every case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)