### PR TITLE
fix(cli): guarantee visible errors on non-zero exit + TTY-aware spinner

### DIFF
--- a/cmd/relicta/main.go
+++ b/cmd/relicta/main.go
@@ -19,6 +19,9 @@ var (
 func main() {
 	cli.SetVersionInfo(ver, commit, date)
 	if err := cli.Execute(); err != nil {
+		// cobra runs with SilenceErrors; surface the error ourselves so a
+		// non-zero exit is never silent.
+		cli.ReportError(err)
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
+	go.klarlabs.de/bolt v1.5.2
 	go.klarlabs.de/fortify v1.6.0
 	go.klarlabs.de/mcp v1.15.0
 	go.klarlabs.de/statekit v1.8.0
@@ -36,6 +37,7 @@ require (
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
+	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0
 	google.golang.org/genai v1.59.0
 	google.golang.org/grpc v1.81.1
@@ -140,7 +142,6 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.klarlabs.de/bolt v1.5.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
@@ -150,7 +151,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/term v0.43.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/internal/cli/output_hygiene_test.go
+++ b/internal/cli/output_hygiene_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// captureStderrHygiene captures stderr for test assertions.
+func captureStderrHygiene(fn func()) string {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	fn()
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	os.Stderr = old
+	return buf.String()
+}
+
+func TestReportError_WritesToStderr(t *testing.T) {
+	// A non-nil error must surface on stderr so a non-zero exit is never silent.
+	errOut := captureStderrHygiene(func() {
+		ReportError(errors.New("boom happened"))
+	})
+	assert.Contains(t, errOut, "boom happened")
+
+	// And it must NOT leak onto stdout, where machine consumers read --json.
+	stdOut := captureStdoutCov(func() {
+		ReportError(errors.New("boom happened"))
+	})
+	assert.Empty(t, stdOut)
+}
+
+func TestReportError_NilIsNoop(t *testing.T) {
+	out := captureStderrHygiene(func() { ReportError(nil) })
+	assert.Empty(t, out)
+}
+
+func TestPrintError_GoesToStderrNotStdout(t *testing.T) {
+	stdOut := captureStdoutCov(func() { printError("diagnostic") })
+	assert.Empty(t, stdOut, "errors must not pollute stdout")
+}
+
+func TestPrintErrorResult_GoesToStdout(t *testing.T) {
+	// In-table failure rows are command output, so they belong on stdout.
+	stdOut := captureStdoutCov(func() { printErrorResult("  push: auth failed") })
+	assert.Contains(t, stdOut, "push: auth failed")
+}
+
+func TestSpinner_DisabledIsInert(t *testing.T) {
+	// Under test (stderr is not a TTY) the spinner must emit nothing — no
+	// cursor escapes that would leak as "[K" in redirected output.
+	origJSON, origCI := outputJSON, ciMode
+	defer func() { outputJSON, ciMode = origJSON, origCI }()
+	outputJSON, ciMode = false, false
+
+	out := captureStderrHygiene(func() {
+		s := NewSpinner("working")
+		assert.False(t, s.active, "spinner should be inert on a non-TTY stderr")
+		s.Start()
+		s.Stop()
+	})
+	assert.Empty(t, out)
+}
+
+func TestSpinnerEnabled_FalseInJSONOrCI(t *testing.T) {
+	origJSON, origCI := outputJSON, ciMode
+	defer func() { outputJSON, ciMode = origJSON, origCI }()
+
+	outputJSON, ciMode = true, false
+	assert.False(t, spinnerEnabled(), "--json must disable the spinner")
+
+	outputJSON, ciMode = false, true
+	assert.False(t, spinnerEnabled(), "CI mode must disable the spinner")
+}

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -75,7 +75,7 @@ func outputStepResults(results []releaseapp.StepResult) {
 		} else if result.Success {
 			printSuccess(fmt.Sprintf("  %s: %s", result.StepName, result.Output))
 		} else {
-			printError(fmt.Sprintf("  %s: %s", result.StepName, result.Error))
+			printErrorResult(fmt.Sprintf("  %s: %s", result.StepName, result.Error))
 		}
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/term"
 
 	"github.com/relicta-tech/relicta/v4/internal/config"
 	"github.com/relicta-tech/relicta/v4/internal/logging"
@@ -517,8 +518,29 @@ func printSuccess(msg string) {
 	fmt.Println(styles.Success.Render("✓ " + security.Mask(msg)))
 }
 
+// printError writes a masked error to stderr. Errors are diagnostics, not
+// command output — keeping them off stdout means machine consumers parsing a
+// command's stdout (e.g. --json) never see error chrome mixed into the data.
 func printError(msg string) {
+	fmt.Fprintln(os.Stderr, styles.Error.Render("✗ "+security.Mask(msg)))
+}
+
+// printErrorResult renders an error-styled line to stdout. Use it for failure
+// rows inside a results table (alongside printSuccess/printInfo), where the
+// line is part of the command's output — not for top-level diagnostics, which
+// belong on stderr via printError.
+func printErrorResult(msg string) {
 	fmt.Println(styles.Error.Render("✗ " + security.Mask(msg)))
+}
+
+// ReportError prints a top-level command error to stderr. cobra runs with
+// SilenceErrors, so without this a non-zero exit from Execute would be silent
+// (issue: `relicta plan` exited 1 with no message). Call once from main.
+func ReportError(err error) {
+	if err == nil {
+		return
+	}
+	printError(err.Error())
 }
 
 func printWarning(msg string) {
@@ -561,11 +583,24 @@ func probeBackendHealth(baseURL string) string {
 	return "unreachable"
 }
 
-// Spinner provides a simple CLI loading indicator.
+// Spinner provides a simple CLI loading indicator. It animates on stderr only
+// when stderr is an interactive terminal — never in CI, when --json is set, or
+// when output is piped. This keeps cursor-control escape sequences (\r, \033[K)
+// out of redirected output, where they previously leaked as "[K" artifacts.
 type Spinner struct {
 	message string
 	stop    chan struct{}
 	done    chan struct{}
+	active  bool
+}
+
+// spinnerEnabled reports whether an animated spinner is appropriate: stderr is
+// a TTY and the operator hasn't requested machine-readable / CI output.
+func spinnerEnabled() bool {
+	if outputJSON || ciMode {
+		return false
+	}
+	return term.IsTerminal(int(os.Stderr.Fd()))
 }
 
 // NewSpinner creates a new spinner with a message.
@@ -574,11 +609,15 @@ func NewSpinner(message string) *Spinner {
 		message: message,
 		stop:    make(chan struct{}),
 		done:    make(chan struct{}),
+		active:  spinnerEnabled(),
 	}
 }
 
-// Start begins the spinner animation.
+// Start begins the spinner animation. No-op on a non-interactive stderr.
 func (s *Spinner) Start() {
+	if !s.active {
+		return
+	}
 	frames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 	go func() {
 		defer close(s.done)
@@ -588,22 +627,24 @@ func (s *Spinner) Start() {
 		for {
 			select {
 			case <-s.stop:
-				// Clear the spinner line
-				fmt.Printf("\r\033[K")
+				// Clear the spinner line.
+				fmt.Fprintf(os.Stderr, "\r\033[K")
 				return
 			case <-ticker.C:
-				fmt.Printf("\r%s %s", styles.Info.Render(frames[i%len(frames)]), s.message)
+				fmt.Fprintf(os.Stderr, "\r%s %s", styles.Info.Render(frames[i%len(frames)]), s.message)
 				i++
 			}
 		}
 	}()
 }
 
-// Stop stops the spinner.
+// Stop stops the spinner. No-op (no stray newline) when it never animated.
 func (s *Spinner) Stop() {
+	if !s.active {
+		return
+	}
 	close(s.stop)
 	<-s.done
-	fmt.Println() // Ensure we're on a new line after spinner
 }
 
 // StopWithSuccess stops the spinner and shows a success message.


### PR DESCRIPTION
Output-hygiene initiative (task #15). Three fixes:

### 1. Silent failures (the `relicta plan` exit-1 bug)
`main` swallowed `Execute()`'s error and called `os.Exit(1)` with no output; combined with cobra's `SilenceErrors`, **every** command failure exited 1 silently. `main` now calls `cli.ReportError`, printing the masked error to stderr.

Before:
```
$ relicta plan; echo $?
Release Plan
[K
1
```
After:
```
$ relicta plan; echo $?
Release Plan
✗ failed to plan release: ... reference not found
1
```

### 2. Spinner artifacts
The spinner wrote `\r`/`\033[K` to stdout unconditionally, leaking `[K` into piped output and polluting stdout for `--json` consumers. Now writes to **stderr** and only animates when stderr is a **TTY** (never under `--json`, CI, or a pipe).

### 3. Error stream
`printError` now goes to **stderr** (was stdout). Added `printErrorResult` for failure rows inside results tables (command output → stays on stdout), keeping the publish step-results table intact.

Adds `output_hygiene_test.go` covering all three. Full suite green (except the pre-existing darwin-only git symlink tests, which pass on Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)