### PR TITLE
fix(security): stop inferring actor trust from spoofable environment

### DIFF
--- a/internal/application/governance/config.go
+++ b/internal/application/governance/config.go
@@ -164,9 +164,18 @@ func buildRule(cfg config.GovernancePolicyConfig) policy.Rule {
 }
 
 // IsActorTrusted checks if an actor is in the trusted actors list.
+//
+// An entry matches either the actor's full kind-scoped ID ("human:alice",
+// "ci:deploy-bot") or its bare name ("alice"). The scoped form lets operators
+// grant trust to a human without also trusting a CI actor that happens to run
+// under the same identity (e.g. GITHUB_ACTOR=alice in a workflow); the bare
+// form is kept for backwards compatibility with existing allowlists.
 func IsActorTrusted(cfg *config.GovernanceConfig, actor cgp.Actor) bool {
 	for _, trusted := range cfg.TrustedActors {
-		if actor.ID == trusted {
+		if trusted == "" {
+			continue
+		}
+		if actor.ID == trusted || (actor.Name != "" && actor.Name == trusted) {
 			return true
 		}
 	}

--- a/internal/cli/approve.go
+++ b/internal/cli/approve.go
@@ -507,19 +507,22 @@ func createCGPActor() cgp.Actor {
 		identity = actor
 	}
 
-	// Determine trust level
-	trustLevel := cgp.TrustLevelLimited
-	if kind == cgp.ActorKindHuman {
-		trustLevel = cgp.TrustLevelTrusted
-	}
+	id := fmt.Sprintf("%s:%s", kind.String(), identity)
 
-	// Check if actor is in trusted list
-	if governance.IsActorTrusted(&cfg.Governance, cgp.Actor{ID: identity}) {
+	// Trust level. Trust is NEVER inferred from actor kind or the absence of CI
+	// markers — both are environment signals an attacker can spoof to escalate.
+	// (Previously a "human" actor — i.e. any invocation with no CI markers set —
+	// was granted TrustLevelTrusted, so unsetting CI=true was enough to unlock
+	// auto-approval.) Every actor now starts Limited (may propose, may NOT
+	// auto-approve); elevation to Full requires explicit membership in the
+	// operator-authored governance.trusted_actors allowlist.
+	trustLevel := cgp.TrustLevelLimited
+	if governance.IsActorTrusted(&cfg.Governance, cgp.Actor{ID: id, Name: identity}) {
 		trustLevel = cgp.TrustLevelFull
 	}
 
 	return cgp.Actor{
-		ID:         fmt.Sprintf("%s:%s", kind.String(), identity),
+		ID:         id,
 		Kind:       kind,
 		Name:       identity,
 		TrustLevel: trustLevel,

--- a/internal/cli/approve_helpers_extra_test.go
+++ b/internal/cli/approve_helpers_extra_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/relicta-tech/relicta/v4/internal/cgp"
 	"github.com/relicta-tech/relicta/v4/internal/config"
 )
 
@@ -59,5 +60,61 @@ func TestCreateCGPActorCI(t *testing.T) {
 	}
 	if actor.TrustLevel == 3 {
 		t.Fatal("expected ci actor not to have full trust level")
+	}
+}
+
+// TestCreateCGPActorUntrustedHumanIsLimited locks in the trust-spoofing fix:
+// a human actor that is NOT in the trusted-actors allowlist must stay Limited
+// and must NOT be able to auto-approve. Previously any invocation without CI
+// markers was granted TrustLevelTrusted, so clearing CI=true unlocked
+// auto-approval.
+func TestCreateCGPActorUntrustedHumanIsLimited(t *testing.T) {
+	cfg = config.DefaultConfig()
+	defer cleanupEnv("CI", "GITHUB_ACTOR", "GITHUB_ACTIONS", "GITLAB_CI", "JENKINS_URL", "USER")()
+
+	os.Unsetenv("CI")
+	os.Unsetenv("GITHUB_ACTOR")
+	os.Unsetenv("GITHUB_ACTIONS")
+	os.Unsetenv("GITLAB_CI")
+	os.Unsetenv("JENKINS_URL")
+	os.Setenv("USER", "stranger")
+	cfg.Governance.TrustedActors = nil // empty allowlist
+
+	actor := createCGPActor()
+
+	if actor.Kind != "human" {
+		t.Fatalf("expected human kind, got %s", actor.Kind)
+	}
+	if actor.TrustLevel != cgp.TrustLevelLimited {
+		t.Fatalf("untrusted human must be Limited, got %d", actor.TrustLevel)
+	}
+	if actor.TrustLevel.CanAutoApprove() {
+		t.Fatal("untrusted human must NOT be able to auto-approve")
+	}
+}
+
+// TestCreateCGPActorTrustScopedByKind verifies a kind-scoped allowlist entry
+// (human:alice) does not also trust a CI actor running under the same identity
+// (GITHUB_ACTOR=alice), closing a same-name escalation path.
+func TestCreateCGPActorTrustScopedByKind(t *testing.T) {
+	cfg = config.DefaultConfig()
+	defer cleanupEnv("CI", "GITHUB_ACTOR", "GITHUB_ACTIONS", "GITLAB_CI", "JENKINS_URL", "USER")()
+
+	cfg.Governance.TrustedActors = []string{"human:alice"}
+
+	os.Setenv("CI", "true")
+	os.Setenv("GITHUB_ACTOR", "alice")
+	ciActor := createCGPActor()
+	if ciActor.TrustLevel == cgp.TrustLevelFull {
+		t.Fatal("ci:alice must not match a human:alice trust entry")
+	}
+
+	os.Unsetenv("CI")
+	os.Unsetenv("GITHUB_ACTIONS")
+	os.Unsetenv("GITHUB_ACTOR")
+	os.Setenv("USER", "alice")
+	humanActor := createCGPActor()
+	if humanActor.TrustLevel != cgp.TrustLevelFull {
+		t.Fatalf("human:alice must match its trust entry, got %d", humanActor.TrustLevel)
 	}
 }


### PR DESCRIPTION
Deferred security item (task #19).

### The hole
`createCGPActor` granted `TrustLevelTrusted` to any "human" actor — and an actor is "human" simply when no CI markers (`CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `JENKINS_URL`) are set. The evaluator's auto-approval rule honors this:
```go
if proposal.Actor.TrustLevel.CanAutoApprove() && risk < threshold && ... {
    decision = Approved
}
```
So an attacker who controls the environment could **clear `CI=true` to masquerade as a trusted human** and unlock auto-approval of low-risk changes without human review. Setting `GITHUB_ACTOR` to a trusted-list name escalated further to Full.

### The fix
- Trust is **never** inferred from actor kind or the absence of CI markers. Every actor starts `Limited` (may propose, may NOT auto-approve).
- Elevation to `Full` requires explicit membership in the operator-authored `governance.trusted_actors` allowlist.
- `IsActorTrusted` now matches the **kind-scoped ID** (`human:alice`) or the bare name (`alice`), so operators can trust a human without also trusting a CI actor running under the same identity (`GITHUB_ACTOR=alice`). Bare-name entries stay supported for back-compat.

### Behavior change
Local auto-approval is now opt-in: a maintainer who wants low-risk auto-approval must add their identity to `governance.trusted_actors`. This is the correct posture for a governance tool — auto-approval should be a deliberate config choice, not an implicit default from the environment.

Tests cover: untrusted human is Limited + cannot auto-approve; kind-scoped trust does not leak across kinds. Existing trusted-human / CI tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)