### PR TITLE
feat(governance): activate risk calibration + actor-reputation guarding

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -442,11 +442,39 @@ governance:
   # Always require humans for high-impact areas
   require_human_for_breaking: true
   require_human_for_security: true
-  # Optional trust list for low-risk automation
+  # Optional trust list for low-risk automation. Entries match an actor's
+  # kind-scoped ID ("human:alice", "ci:release-bot") or its bare name
+  # ("alice"). Trust is NEVER inferred from the environment — only actors on
+  # this list may auto-approve; everyone else can propose but not self-approve.
   trusted_actors:
-    - github-actions
-    - ci-release-bot
+    - human:alice
+    - ci:release-bot
 ```
+
+### Adaptive Risk: Calibration & Reputation
+
+Two learning loops feed on Release History. Both are **off by default** because
+they change evaluation outcomes; enable them once you have a track record. Both
+require `memory_enabled: true`.
+
+```yaml
+governance:
+  memory_enabled: true
+  # Retune the risk model's factor weights from historical release outcomes.
+  # Calibration runs once per process from stored history; weights that better
+  # predicted past failures are emphasized.
+  calibration_enabled: true
+  # Guard auto-approval by actor reputation. An actor with a demonstrated poor
+  # track record (>= 3 release records and a "restricted" reputation level) has
+  # auto-approved decisions downgraded to require human review. This only ever
+  # TIGHTENS a decision — it never auto-approves something that wasn't already
+  # approved, and never penalizes actors with too little history.
+  reputation_enabled: true
+```
+
+When the reputation guard fires, the evaluation rationale records why
+(`actor reputation is restricted (…%, restricted) — human review required`), so
+the downgrade is always visible in `relicta evaluate` output and the audit trail.
 
 ## Release History
 

--- a/internal/application/governance/activation.go
+++ b/internal/application/governance/activation.go
@@ -1,0 +1,159 @@
+package governance
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/relicta-tech/relicta/v4/internal/cgp"
+	"github.com/relicta-tech/relicta/v4/internal/cgp/memory"
+	"github.com/relicta-tech/relicta/v4/internal/cgp/reputation"
+	"github.com/relicta-tech/relicta/v4/internal/cgp/risk"
+)
+
+const (
+	// calibrationHistoryLimit bounds how many historical releases feed a
+	// calibration run.
+	calibrationHistoryLimit = 500
+
+	// reputationHistoryLimit bounds how many historical releases/incidents feed
+	// a reputation computation.
+	reputationHistoryLimit = 200
+
+	// minReputationSamples is the minimum number of an actor's own release
+	// records required before reputation may tighten a decision. Below this we
+	// have too little signal and never penalize the actor.
+	minReputationSamples = 3
+)
+
+// ensureCalibrated retunes the evaluator's risk weights from historical release
+// outcomes exactly once per Service lifetime. Failures are logged and ignored —
+// calibration is an optimization, never a hard dependency of evaluation.
+func (s *Service) ensureCalibrated(ctx context.Context, repository string) {
+	s.calibrateOnce.Do(func() {
+		records, err := s.memoryStore.GetReleaseHistory(ctx, repository, calibrationHistoryLimit)
+		if err != nil {
+			s.logger.Warn("risk calibration skipped: could not load release history", "error", err)
+			return
+		}
+		if len(records) == 0 {
+			s.logger.Debug("risk calibration skipped: no historical releases")
+			return
+		}
+
+		calRecords := toCalibrationRecords(records)
+		result := risk.NewCalibrator().Calibrate(calRecords)
+		s.evaluator.ApplyCalibration(result)
+
+		s.logger.Info("risk weights calibrated from history",
+			"samples", result.SampleSize,
+			"accuracy", result.Accuracy,
+			"calibrated_at", result.CalibratedAt)
+	})
+}
+
+// toCalibrationRecords maps memory release records into calibration records.
+// Per-factor scores are approximated from the record's tags carrying the
+// release's overall risk score, mirroring the analytics calibration path.
+func toCalibrationRecords(records []*memory.ReleaseRecord) []risk.CalibrationRecord {
+	out := make([]risk.CalibrationRecord, 0, len(records))
+	for _, r := range records {
+		if r == nil {
+			continue
+		}
+		factorScores := make(map[string]float64, len(r.Tags))
+		for _, tag := range r.Tags {
+			factorScores[tag] = r.RiskScore
+		}
+		out = append(out, risk.CalibrationRecord{
+			RiskScore:    r.RiskScore,
+			FactorScores: factorScores,
+			Outcome:      string(r.Outcome),
+			ReleasedAt:   r.ReleasedAt,
+		})
+	}
+	return out
+}
+
+// applyReputationGuard computes the initiating actor's reputation and, when it
+// is poor enough on a sufficient sample, downgrades an auto-approved decision to
+// require human review. It only ever tightens the decision.
+func (s *Service) applyReputationGuard(ctx context.Context, input EvaluateReleaseInput, output *EvaluateReleaseOutput) {
+	score, ok := s.computeReputation(ctx, input.Repository, input.Actor.ID)
+	if !ok {
+		return
+	}
+
+	info := &ReputationInfo{
+		Overall:    score.Overall,
+		Level:      score.Level(),
+		SampleSize: score.SampleSize,
+		Trend:      string(score.Trend),
+	}
+	output.Reputation = info
+
+	// Only act on actors with a real, sufficiently-sampled poor track record.
+	// Newcomers (SampleSize below the floor) are never penalized.
+	if score.SampleSize < minReputationSamples {
+		return
+	}
+	if score.Overall >= reputation.ThresholdProbation {
+		return
+	}
+
+	// Tighten: an auto-approved / approved decision now needs human review.
+	if output.Decision == cgp.DecisionApproved {
+		output.Decision = cgp.DecisionApprovalRequired
+		output.CanAutoApprove = false
+		info.Guarded = true
+		rationale := fmt.Sprintf("actor reputation is restricted (%.1f%%, %s) — human review required",
+			score.Overall*100, score.Level())
+		output.Rationale = append(output.Rationale, rationale)
+		output.RequiredActions = append(output.RequiredActions, cgp.RequiredAction{
+			Type:        "human_approval",
+			Description: "Review release from a low-reputation actor before proceeding",
+		})
+		s.logger.Warn("reputation guard downgraded decision",
+			"actor", input.Actor.ID,
+			"reputation", score.Overall,
+			"level", score.Level(),
+			"samples", score.SampleSize)
+	}
+}
+
+// computeReputation loads the actor's release and incident history and computes
+// a reputation score. Returns ok=false when history cannot be loaded.
+func (s *Service) computeReputation(ctx context.Context, repository, actorID string) (reputation.Score, bool) {
+	releases, err := s.memoryStore.GetReleaseHistory(ctx, repository, reputationHistoryLimit)
+	if err != nil {
+		s.logger.Debug("reputation skipped: could not load release history", "error", err)
+		return reputation.Score{}, false
+	}
+	incidents, err := s.memoryStore.GetIncidentHistory(ctx, repository, reputationHistoryLimit)
+	if err != nil {
+		// Incidents are optional; proceed with releases only.
+		s.logger.Debug("reputation: incident history unavailable", "error", err)
+		incidents = nil
+	}
+
+	engine, err := reputation.NewEngine(noopReputationStore{}, reputation.WithLogger(s.logger))
+	if err != nil {
+		s.logger.Debug("reputation skipped: engine init failed", "error", err)
+		return reputation.Score{}, false
+	}
+	return engine.ComputeScore(releases, incidents, actorID), true
+}
+
+// noopReputationStore satisfies reputation.ReputationStore for compute-only use.
+// ComputeScore is pure; the engine never touches the store on this path, so we
+// avoid persisting reputation during evaluation.
+type noopReputationStore struct{}
+
+func (noopReputationStore) GetScore(context.Context, string) (*reputation.Score, error) {
+	return nil, nil
+}
+func (noopReputationStore) SaveScore(context.Context, string, *reputation.Score) error {
+	return nil
+}
+func (noopReputationStore) GetHistory(context.Context, string, int) ([]reputation.Score, error) {
+	return nil, nil
+}

--- a/internal/application/governance/activation_test.go
+++ b/internal/application/governance/activation_test.go
@@ -1,0 +1,192 @@
+package governance
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/relicta-tech/relicta/v4/internal/cgp"
+	"github.com/relicta-tech/relicta/v4/internal/cgp/evaluator"
+	"github.com/relicta-tech/relicta/v4/internal/cgp/memory"
+	"github.com/relicta-tech/relicta/v4/internal/cgp/policy"
+	"github.com/relicta-tech/relicta/v4/internal/cgp/risk"
+)
+
+const guardActorID = "human:bad@example.com"
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func testEvaluator() *evaluator.Evaluator {
+	return evaluator.New(
+		evaluator.WithRiskCalculator(risk.NewCalculatorWithDefaults()),
+		evaluator.WithPolicyEngine(policy.NewEngine(nil, nil)),
+	)
+}
+
+// seedIncidents records unresolved incidents for an actor, tanking the
+// incident-rate and recovery-speed reputation components.
+func seedIncidents(t *testing.T, store *memory.InMemoryStore, actorID, repo string, n int) {
+	t.Helper()
+	ctx := context.Background()
+	for i := 0; i < n; i++ {
+		inc := &memory.IncidentRecord{
+			ID:         repo + "-inc-" + itoaTest(i),
+			ReleaseID:  repo + "-rel-" + itoaTest(i),
+			Repository: repo,
+			ActorID:    actorID,
+			Severity:   cgp.SeverityHigh,
+			DetectedAt: time.Now().Add(-time.Duration(i) * time.Hour),
+		}
+		if err := store.RecordIncident(ctx, inc); err != nil {
+			t.Fatalf("seed incident: %v", err)
+		}
+	}
+}
+
+func seedReleases(t *testing.T, store *memory.InMemoryStore, actorID, repo string, outcome memory.ReleaseOutcome, n int) {
+	t.Helper()
+	ctx := context.Background()
+	actor := cgp.Actor{ID: actorID, Kind: cgp.ActorKindHuman, Name: actorID}
+	for i := 0; i < n; i++ {
+		rec := &memory.ReleaseRecord{
+			ID:         repo + "-rel-" + itoaTest(i),
+			Repository: repo,
+			Version:    "v1.0." + itoaTest(i),
+			Actor:      actor,
+			RiskScore:  0.3,
+			Decision:   cgp.DecisionApproved,
+			Outcome:    outcome,
+			ReleasedAt: time.Now().Add(-time.Duration(i) * time.Hour),
+			Duration:   time.Minute,
+		}
+		if err := store.RecordRelease(ctx, rec); err != nil {
+			t.Fatalf("seed release: %v", err)
+		}
+	}
+}
+
+func itoaTest(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func newGuardService(store *memory.InMemoryStore) *Service {
+	return &Service{
+		logger:            testLogger(),
+		memoryStore:       store,
+		reputationEnabled: true,
+	}
+}
+
+func TestReputationGuard_DowngradesPoorActor(t *testing.T) {
+	store := memory.NewInMemoryStore()
+	seedReleases(t, store, guardActorID, "owner/repo", memory.OutcomeFailed, 6)
+	seedIncidents(t, store, guardActorID, "owner/repo", 6)
+
+	svc := newGuardService(store)
+	out := &EvaluateReleaseOutput{Decision: cgp.DecisionApproved, CanAutoApprove: true}
+	input := EvaluateReleaseInput{Repository: "owner/repo", Actor: cgp.Actor{ID: guardActorID}}
+
+	svc.applyReputationGuard(context.Background(), input, out)
+
+	if out.Reputation == nil {
+		t.Fatal("expected reputation info attached")
+	}
+	if out.Decision != cgp.DecisionApprovalRequired {
+		t.Fatalf("poor actor must be downgraded, got %s", out.Decision)
+	}
+	if out.CanAutoApprove {
+		t.Fatal("poor actor must not auto-approve")
+	}
+	if !out.Reputation.Guarded {
+		t.Fatal("expected Guarded=true")
+	}
+	if out.Reputation.Overall >= 0.4 {
+		t.Fatalf("expected restricted reputation (<0.4), got %.3f", out.Reputation.Overall)
+	}
+}
+
+func TestReputationGuard_IgnoresInsufficientSamples(t *testing.T) {
+	store := memory.NewInMemoryStore()
+	// Only 2 records — below minReputationSamples; must NOT penalize.
+	seedReleases(t, store, guardActorID, "owner/repo", memory.OutcomeFailed, 2)
+
+	svc := newGuardService(store)
+	out := &EvaluateReleaseOutput{Decision: cgp.DecisionApproved, CanAutoApprove: true}
+	input := EvaluateReleaseInput{Repository: "owner/repo", Actor: cgp.Actor{ID: guardActorID}}
+
+	svc.applyReputationGuard(context.Background(), input, out)
+
+	if out.Decision != cgp.DecisionApproved {
+		t.Fatalf("actor with too few samples must not be downgraded, got %s", out.Decision)
+	}
+	if out.Reputation != nil && out.Reputation.Guarded {
+		t.Fatal("must not guard on insufficient samples")
+	}
+}
+
+func TestReputationGuard_KeepsGoodActorApproved(t *testing.T) {
+	store := memory.NewInMemoryStore()
+	seedReleases(t, store, guardActorID, "owner/repo", memory.OutcomeSuccess, 6)
+
+	svc := newGuardService(store)
+	out := &EvaluateReleaseOutput{Decision: cgp.DecisionApproved, CanAutoApprove: true}
+	input := EvaluateReleaseInput{Repository: "owner/repo", Actor: cgp.Actor{ID: guardActorID}}
+
+	svc.applyReputationGuard(context.Background(), input, out)
+
+	if out.Decision != cgp.DecisionApproved {
+		t.Fatalf("good actor must stay approved, got %s", out.Decision)
+	}
+	if out.Reputation == nil {
+		t.Fatal("expected reputation info attached for actor with history")
+	}
+	if out.Reputation.Guarded {
+		t.Fatal("good actor must not be guarded")
+	}
+}
+
+func TestReputationGuard_NeverLoosens(t *testing.T) {
+	store := memory.NewInMemoryStore()
+	seedReleases(t, store, guardActorID, "owner/repo", memory.OutcomeFailed, 6)
+
+	svc := newGuardService(store)
+	// Decision already requires approval — guard must not flip it to approved.
+	out := &EvaluateReleaseOutput{Decision: cgp.DecisionApprovalRequired, CanAutoApprove: false}
+	input := EvaluateReleaseInput{Repository: "owner/repo", Actor: cgp.Actor{ID: guardActorID}}
+
+	svc.applyReputationGuard(context.Background(), input, out)
+
+	if out.Decision != cgp.DecisionApprovalRequired {
+		t.Fatalf("guard must never loosen; got %s", out.Decision)
+	}
+}
+
+func TestEnsureCalibrated_RunsOnceAndIsSafe(t *testing.T) {
+	store := memory.NewInMemoryStore()
+	seedReleases(t, store, guardActorID, "owner/repo", memory.OutcomeFailed, 4)
+
+	svc := &Service{logger: testLogger(), memoryStore: store, evaluator: testEvaluator(), calibrationEnabled: true}
+
+	// Two calls must not panic; sync.Once guarantees a single calibration.
+	svc.ensureCalibrated(context.Background(), "owner/repo")
+	svc.ensureCalibrated(context.Background(), "owner/repo")
+}
+
+func TestEnsureCalibrated_NoHistoryNoOp(t *testing.T) {
+	store := memory.NewInMemoryStore()
+	svc := &Service{logger: testLogger(), memoryStore: store, evaluator: testEvaluator(), calibrationEnabled: true}
+	// No seeded history — must be a safe no-op.
+	svc.ensureCalibrated(context.Background(), "owner/repo")
+}

--- a/internal/application/governance/config.go
+++ b/internal/application/governance/config.go
@@ -51,6 +51,8 @@ func NewServiceFromConfig(cfg *config.GovernanceConfig, repoPath string, logger 
 	// Create service with evaluator
 	opts := []ServiceOption{
 		WithLogger(logger),
+		WithCalibration(cfg.CalibrationEnabled),
+		WithReputation(cfg.ReputationEnabled),
 	}
 
 	// Set up memory store if enabled

--- a/internal/application/governance/service.go
+++ b/internal/application/governance/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/relicta-tech/relicta/v4/internal/cgp"
@@ -31,6 +32,14 @@ type Service struct {
 	evaluator   *evaluator.Evaluator
 	memoryStore memory.Store
 	logger      *slog.Logger
+
+	// calibrationEnabled retunes risk weights from historical outcomes once,
+	// lazily, on first evaluation. reputationEnabled downgrades auto-approvals
+	// for actors with a demonstrated poor track record. Both require a memory
+	// store and only ever tighten outcomes.
+	calibrationEnabled bool
+	reputationEnabled  bool
+	calibrateOnce      sync.Once
 }
 
 // ServiceOption configures a governance Service.
@@ -47,6 +56,20 @@ func WithLogger(logger *slog.Logger) ServiceOption {
 func WithMemoryStore(store memory.Store) ServiceOption {
 	return func(s *Service) {
 		s.memoryStore = store
+	}
+}
+
+// WithCalibration enables data-driven risk calibration (requires a memory store).
+func WithCalibration(enabled bool) ServiceOption {
+	return func(s *Service) {
+		s.calibrationEnabled = enabled
+	}
+}
+
+// WithReputation enables actor-reputation guarding (requires a memory store).
+func WithReputation(enabled bool) ServiceOption {
+	return func(s *Service) {
+		s.reputationEnabled = enabled
 	}
 }
 
@@ -107,6 +130,25 @@ type EvaluateReleaseOutput struct {
 
 	// HistoricalContext provides historical analysis if available.
 	HistoricalContext *HistoricalContext
+
+	// Reputation is the initiating actor's reputation assessment, when
+	// reputation guarding is enabled and the actor has history. Informational;
+	// the guard's effect is already reflected in Decision/Rationale.
+	Reputation *ReputationInfo
+}
+
+// ReputationInfo summarizes an actor's reputation for evaluation output.
+type ReputationInfo struct {
+	// Overall is the composite reputation score in [0.0, 1.0].
+	Overall float64
+	// Level is the qualitative band: trusted, reliable, probation, restricted.
+	Level string
+	// SampleSize is the number of release records the score is based on.
+	SampleSize int
+	// Trend indicates improving, stable, or declining reputation.
+	Trend string
+	// Guarded is true when poor reputation downgraded the decision.
+	Guarded bool
 }
 
 // HistoricalContext provides historical analysis for a release.
@@ -136,6 +178,12 @@ func (s *Service) EvaluateRelease(ctx context.Context, input EvaluateReleaseInpu
 		return nil, fmt.Errorf("release is required")
 	}
 
+	// Retune risk weights from historical outcomes once, before the first
+	// evaluation, when calibration is enabled.
+	if s.calibrationEnabled && s.memoryStore != nil {
+		s.ensureCalibrated(ctx, input.Repository)
+	}
+
 	// Build change proposal and analysis from release
 	proposal, analysis := s.buildProposalAndAnalysis(input)
 
@@ -154,6 +202,12 @@ func (s *Service) EvaluateRelease(ctx context.Context, input EvaluateReleaseInpu
 		Rationale:       result.Decision.Rationale,
 		Conditions:      result.Decision.Conditions,
 		CanAutoApprove:  result.Decision.Decision == cgp.DecisionApproved,
+	}
+
+	// Reputation guard: downgrade an auto-approval when the initiating actor has
+	// a demonstrated poor track record. Tightens only — never loosens.
+	if s.reputationEnabled && s.memoryStore != nil {
+		s.applyReputationGuard(ctx, input, output)
 	}
 
 	// Add historical context if requested and available

--- a/internal/cgp/evaluator/evaluator.go
+++ b/internal/cgp/evaluator/evaluator.go
@@ -94,6 +94,13 @@ func WithRiskCalculator(calc *risk.Calculator) Option {
 	}
 }
 
+// ApplyCalibration retunes the evaluator's risk-calculator weights from a
+// calibration result computed against historical release outcomes. Subsequent
+// Evaluate/EvaluateQuick calls use the calibrated weights.
+func (e *Evaluator) ApplyCalibration(result risk.CalibrationResult) {
+	e.riskCalculator.ApplyCalibration(result)
+}
+
 // WithPolicyEngine sets a custom policy engine.
 func WithPolicyEngine(engine *policy.Engine) Option {
 	return func(e *Evaluator) {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -461,6 +461,16 @@ type GovernanceConfig struct {
 	// slider). When empty, safe defaults apply: humans permissive,
 	// agents/CI restrictive.
 	ActorBudgetPath string `mapstructure:"actor_budget_path" json:"actor_budget_path,omitempty"`
+	// CalibrationEnabled turns on data-driven risk calibration: the evaluator's
+	// risk weights are tuned once from historical release outcomes in the memory
+	// store. Requires MemoryEnabled. Off by default — it changes risk scores.
+	CalibrationEnabled bool `mapstructure:"calibration_enabled" json:"calibration_enabled,omitempty"`
+	// ReputationEnabled turns on actor-reputation guarding: an actor with a
+	// demonstrated poor track record (enough samples, restricted level) has
+	// auto-approved decisions downgraded to require human review. It only ever
+	// tightens a decision, never loosens one. Requires MemoryEnabled. Off by
+	// default — it changes evaluation outcomes.
+	ReputationEnabled bool `mapstructure:"reputation_enabled" json:"reputation_enabled,omitempty"`
 }
 
 // RiskBudgetConfig configures cumulative risk budget limits.


### PR DESCRIPTION
Deferred item (task #18). Two learning loops existed in the codebase but were never wired into live evaluation — the risk `Calibrator` (only run for analytics display) and the reputation `Engine` (zero production callers). Both now plug into the governance `Service`, **gated by config and off by default** (they change evaluation outcomes).

### Calibration — `governance.calibration_enabled`
On first evaluation, the evaluator's risk-factor weights are retuned **once** from historical release outcomes in the memory store, emphasizing factors that better predicted past failures. Adds `Evaluator.ApplyCalibration`. Safe no-op when there's no history.

### Reputation — `governance.reputation_enabled`
Each evaluation computes the initiating actor's reputation from release + incident history. An actor with a **demonstrated poor track record** (≥3 records, "restricted" level, overall < 0.4) has an auto-approved decision **downgraded to require human review**, with a rationale recorded in the output and audit trail.

Safety invariants (tested):
- **Only tightens** — never loosens a decision, never auto-approves.
- **Never penalizes newcomers** — actors below 3 samples score neutral (0.5) and are skipped.
- Computed **without persistence** (no-op store) — no side effects on evaluation.

### Scope
Both require `memory_enabled`. Wiring lives entirely in the governance package (`activation.go`); no container changes. `trusted_actors` docs updated with the env-spoofing-safe guidance from #155.

Tests: poor actor downgraded; insufficient-sample actor untouched; good actor stays approved; guard never loosens; calibration runs once and is safe with/without history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)