### PR TITLE
test(cli): cover health exit-code paths; extract pure status→code mapping

### DIFF
--- a/internal/cli/execute_test.go
+++ b/internal/cli/execute_test.go
@@ -2,37 +2,82 @@
 package cli
 
 import (
-	"context"
+	"bytes"
 	"testing"
 )
 
+// runRootWithArgs points the global rootCmd at the given args and discards its
+// output for the rest of the test, restoring both on cleanup. "--help" exits
+// cleanly (cobra returns nil and skips RunE/PersistentPreRunE), so it exercises
+// the Execute wrappers without side effects or os.Exit.
+func runRootWithArgs(t *testing.T, args []string) {
+	t.Helper()
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+}
+
 func TestExecute(t *testing.T) {
-	// Execute can be tested but would require command setup
-	// For now, verify it doesn't panic with a simple test
-	// We'll skip full execution as it requires complex setup
-	t.Skip("Requires full command execution setup")
+	runRootWithArgs(t, []string{"--help"})
+	if err := Execute(); err != nil {
+		t.Fatalf("Execute() with --help error = %v", err)
+	}
 }
 
 func TestExecuteContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Execute with context would require command setup
-	// Test that the function exists and can be called
-	_ = ctx
-	t.Skip("Requires full command execution setup")
+	runRootWithArgs(t, []string{"--help"})
+	if err := ExecuteContext(t.Context()); err != nil {
+		t.Fatalf("ExecuteContext() with --help error = %v", err)
+	}
 }
 
-func TestExitWithHealthStatus(t *testing.T) {
-	// Create a test health report
-	report := &HealthReport{
-		Status:      HealthStatusHealthy,
-		Components:  []ComponentHealth{},
-		Environment: make(map[string]string),
+func TestHealthStatusExitCode(t *testing.T) {
+	tests := []struct {
+		name   string
+		status HealthStatus
+		want   int
+	}{
+		{"healthy is zero", HealthStatusHealthy, 0},
+		{"degraded is one", HealthStatusDegraded, 1},
+		{"unhealthy is two", HealthStatusUnhealthy, 2},
+		{"unknown status is zero", HealthStatus("bogus"), 0},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := healthStatusExitCode(tt.status); got != tt.want {
+				t.Fatalf("healthStatusExitCode(%q) = %d, want %d", tt.status, got, tt.want)
+			}
+		})
+	}
+}
 
-	// This function calls os.Exit which we can't easily test
-	// We'll just verify it exists
-	_ = report
-	t.Skip("Function calls os.Exit, cannot test easily")
+// withCapturedHealthExit replaces the exit hook with one that records the status
+// instead of calling os.Exit, returning a pointer to the captured value and
+// restoring the hook on cleanup.
+func withCapturedHealthExit(t *testing.T) *HealthStatus {
+	t.Helper()
+	var captured HealthStatus = "<none>"
+	orig := exitWithHealthStatusHook
+	exitWithHealthStatusHook = func(status HealthStatus) error {
+		captured = status
+		return nil
+	}
+	t.Cleanup(func() { exitWithHealthStatusHook = orig })
+	return &captured
+}
+
+func TestExitWithHealthStatus_DelegatesToHook(t *testing.T) {
+	captured := withCapturedHealthExit(t)
+
+	if err := exitWithHealthStatus(HealthStatusUnhealthy); err != nil {
+		t.Fatalf("exitWithHealthStatus() error = %v", err)
+	}
+	if *captured != HealthStatusUnhealthy {
+		t.Fatalf("hook received %q, want %q", *captured, HealthStatusUnhealthy)
+	}
 }

--- a/internal/cli/health.go
+++ b/internal/cli/health.go
@@ -333,14 +333,27 @@ func outputHealthText(report *HealthReport) error {
 	return exitWithHealthStatus(report.Status)
 }
 
-var exitWithHealthStatusHook = func(status HealthStatus) error {
+// healthStatusExitCode maps a health status to its process exit code:
+// 0 = healthy, 1 = degraded, 2 = unhealthy. Any unknown status maps to 0 so an
+// unrecognized state never wedges the process on a non-zero exit. Pure so the
+// mapping can be tested without forking a process.
+func healthStatusExitCode(status HealthStatus) int {
 	switch status {
-	case HealthStatusHealthy:
-		return nil
 	case HealthStatusDegraded:
-		os.Exit(1)
+		return 1
 	case HealthStatusUnhealthy:
-		os.Exit(2)
+		return 2
+	default:
+		return 0
+	}
+}
+
+// exitWithHealthStatusHook performs the process exit for a health status. It is
+// a var so tests can substitute a capturing implementation in place of the real
+// os.Exit side effect.
+var exitWithHealthStatusHook = func(status HealthStatus) error {
+	if code := healthStatusExitCode(status); code != 0 {
+		os.Exit(code)
 	}
 	return nil
 }

--- a/internal/cli/health_comprehensive_test.go
+++ b/internal/cli/health_comprehensive_test.go
@@ -179,13 +179,9 @@ func TestOutputHealthJSON_Coverage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.status != HealthStatusHealthy {
-				// exitWithHealthStatus calls os.Exit for non-healthy states
-				// We can't test those paths without forking, but we can test
-				// the JSON encoding part by checking that it doesn't panic
-				// before reaching exitWithHealthStatus
-				t.Skip("Skipping test that would call os.Exit")
-			}
+			// Capture the exit so non-healthy statuses, which would otherwise
+			// os.Exit, run through the full JSON-encoding path.
+			captured := withCapturedHealthExit(t)
 
 			report := &HealthReport{
 				Status: tt.status,
@@ -204,10 +200,11 @@ func TestOutputHealthJSON_Coverage(t *testing.T) {
 				},
 			}
 
-			// Just verify it doesn't panic for healthy status
-			err := outputHealthJSON(report)
-			if err != nil {
+			if err := outputHealthJSON(report); err != nil {
 				t.Errorf("outputHealthJSON() error = %v", err)
+			}
+			if *captured != tt.status {
+				t.Errorf("exit hook saw %q, want %q", *captured, tt.status)
 			}
 		})
 	}
@@ -258,10 +255,9 @@ func TestOutputHealthText_AllStatuses(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.status != HealthStatusHealthy {
-				// Skip non-healthy as they call os.Exit
-				t.Skip("Skipping test that would call os.Exit")
-			}
+			// Capture the exit so non-healthy statuses run the full text-render
+			// path instead of calling os.Exit.
+			captured := withCapturedHealthExit(t)
 
 			report := &HealthReport{
 				Status: tt.status,
@@ -274,9 +270,11 @@ func TestOutputHealthText_AllStatuses(t *testing.T) {
 				},
 			}
 
-			err := outputHealthText(report)
-			if err != nil {
+			if err := outputHealthText(report); err != nil {
 				t.Errorf("outputHealthText() error = %v", err)
+			}
+			if *captured != tt.status {
+				t.Errorf("exit hook saw %q, want %q", *captured, tt.status)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Independent of the governance work (#158/#159) — branches off `main`.

The health command's `os.Exit` paths were untested: three `t.Skip` calls left release-blocking exit-code behavior unverified (`execute_test.go`, `health_comprehensive_test.go`).

## Change
Extract the status→exit-code decision into a pure `healthStatusExitCode` function (0 healthy / 1 degraded / 2 unhealthy / unknown→0), separated from the `os.Exit` side effect behind the existing `exitWithHealthStatusHook` seam — so the mapping is testable without forking a process.

Tests now cover:
- `healthStatusExitCode` — table test over all statuses incl. unknown
- `exitWithHealthStatus` — delegates to the hook
- `outputHealthJSON` / `outputHealthText` — exercised for **degraded** and **unhealthy** (previously skipped) by capturing the exit hook; asserts the render path runs and the correct status reaches the exit
- `Execute` / `ExecuteContext` — smoke-tested via `--help` (previously skipped)

No behavior change to the binary — pure refactor + tests.

## Verification
- `go test ./internal/cli/` passes (previously-skipped tests now active)
- `golangci-lint run ./internal/cli/` 0 issues