### PR TITLE
feat(plugin): enforce darwin plugin confinement via sandbox-exec seatbelt

### DIFF
--- a/internal/plugin/sandbox/sandbox_darwin.go
+++ b/internal/plugin/sandbox/sandbox_darwin.go
@@ -3,29 +3,36 @@
 package sandbox
 
 import (
+	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"syscall"
+
+	"github.com/relicta-tech/relicta/v4/internal/config"
 )
 
-// applyProcessLimits applies macOS-specific resource limits to the command.
-// Uses setrlimit via SysProcAttr for memory limits.
+// applyProcessLimits applies macOS-specific resource limits to the command and,
+// when capabilities restrict network or filesystem access, wraps the command in
+// a sandbox-exec (seatbelt) profile for real kernel-enforced confinement.
 //
-// SECURITY NOTICE: macOS Resource Limit Limitations
+// SECURITY NOTICE: macOS Enforcement
 //
-// On macOS, plugin sandboxing is BEST-EFFORT only:
+// Resource limits (memory/CPU) remain BEST-EFFORT on macOS:
 //   - Memory limits (RLIMIT_DATA) may be ignored by modern macOS versions
 //   - RLIMIT_AS (address space) is not enforced on Apple Silicon
-//   - CPU limits cannot be enforced without launchd or sandbox-exec
-//   - True isolation requires sandbox-exec profiles (not implemented)
+//   - CPU limits cannot be enforced without launchd job control
 //
-// For production deployments requiring strict plugin isolation:
-//   - Use Linux runners/containers where cgroups provide real limits
-//   - Use Docker with resource constraints
-//   - Set conservative timeouts (primary protection mechanism)
+// Network and filesystem confinement ARE enforced when the `sandbox-exec`
+// binary is available: a seatbelt profile denies outbound network (keeping
+// loopback + unix sockets so the gRPC plugin handshake still works) and confines
+// writes to temp and explicitly-allowed paths. When `sandbox-exec` is missing,
+// the command runs unconfined and a warning is logged.
 //
 // The timeout mechanism in the plugin manager remains the primary protection
-// against runaway plugins on macOS.
+// against runaway (CPU/memory) plugins on macOS.
 func (s *Sandbox) applyProcessLimits(cmd *exec.Cmd) error {
 	if s.capabilities == nil {
 		return nil
@@ -68,7 +75,101 @@ func (s *Sandbox) applyProcessLimits(cmd *exec.Cmd) error {
 	// 2. Timeout mechanism in the plugin manager (primary protection)
 	// True CPU throttling requires launchd job control or sandbox-exec
 
+	// Confine network/filesystem via a seatbelt profile when capabilities ask
+	// for it. Best-effort: a missing sandbox-exec degrades to unconfined.
+	s.wrapWithSeatbelt(cmd)
+
 	return nil
+}
+
+// needsSeatbelt reports whether the capabilities call for a sandbox-exec
+// profile: any network restriction, filesystem restriction, or path allowlist.
+// When everything is permitted there is nothing to enforce and we skip wrapping.
+func needsSeatbelt(caps *config.PluginCapabilities) bool {
+	if caps == nil {
+		return false
+	}
+	return !caps.AllowNetwork || !caps.AllowFilesystem || len(caps.AllowedPaths) > 0
+}
+
+// seatbeltWritablePaths returns the directories a confined plugin may still
+// write to: the system temp locations plus any explicitly-allowed paths. Reads
+// stay unrestricted (the profile is allow-by-default) so dynamic libraries and
+// the plugin binary load normally.
+func seatbeltWritablePaths(caps *config.PluginCapabilities) []string {
+	paths := []string{"/private/tmp", "/private/var/folders"}
+	if tmp := os.Getenv("TMPDIR"); tmp != "" {
+		paths = append(paths, filepath.Clean(tmp))
+	}
+	for _, p := range caps.AllowedPaths {
+		if abs, err := filepath.Abs(p); err == nil {
+			paths = append(paths, abs)
+		}
+	}
+	return paths
+}
+
+// buildSeatbeltProfile renders an SBPL (sandbox profile language) document for
+// the given capabilities. It is allow-by-default and then selectively denies, so
+// the plugin keeps the broad read/exec access it needs to run while losing the
+// specific privileges the operator withheld.
+func buildSeatbeltProfile(caps *config.PluginCapabilities) string {
+	var b strings.Builder
+	b.WriteString("(version 1)\n")
+	b.WriteString("(allow default)\n")
+
+	if !caps.AllowNetwork {
+		// Block external egress but keep loopback and unix sockets so the
+		// go-plugin gRPC handshake (127.0.0.1 / unix socket) still connects.
+		b.WriteString("(deny network-outbound)\n")
+		b.WriteString("(allow network-outbound (remote ip \"localhost:*\"))\n")
+		b.WriteString("(allow network-outbound (remote unix-socket))\n")
+		b.WriteString("(allow network-bind (local ip \"localhost:*\"))\n")
+	}
+
+	if !caps.AllowFilesystem || len(caps.AllowedPaths) > 0 {
+		b.WriteString("(deny file-write*)\n")
+		for _, p := range seatbeltWritablePaths(caps) {
+			fmt.Fprintf(&b, "(allow file-write* (subpath %q))\n", p)
+		}
+		b.WriteString("(allow file-write-data (literal \"/dev/null\") (literal \"/dev/stdout\") (literal \"/dev/stderr\"))\n")
+	}
+
+	return b.String()
+}
+
+// wrapWithSeatbelt rewrites cmd to run under `sandbox-exec -p <profile>` when the
+// capabilities require confinement. If sandbox-exec is unavailable the command is
+// left unchanged and a warning is logged (best-effort, consistent with the
+// resource-limit posture on macOS).
+func (s *Sandbox) wrapWithSeatbelt(cmd *exec.Cmd) {
+	if !needsSeatbelt(s.capabilities) {
+		return
+	}
+
+	sbexec, err := exec.LookPath("sandbox-exec")
+	if err != nil {
+		slog.Warn("sandbox-exec not found; plugin runs without seatbelt confinement",
+			"plugin", s.name,
+			"recommendation", "ensure sandbox-exec is on PATH, or run on Linux for cgroup enforcement")
+		return
+	}
+
+	profile := buildSeatbeltProfile(s.capabilities)
+
+	// sandbox-exec -p <profile> <origBinary> <origArgs...>
+	origPath := cmd.Path
+	newArgs := []string{sbexec, "-p", profile, origPath}
+	if len(cmd.Args) > 1 {
+		newArgs = append(newArgs, cmd.Args[1:]...)
+	}
+	cmd.Path = sbexec
+	cmd.Args = newArgs
+
+	slog.Info("plugin confined with sandbox-exec seatbelt profile",
+		"plugin", s.name,
+		"network_egress_denied", !s.capabilities.AllowNetwork,
+		"filesystem_write_confined", !s.capabilities.AllowFilesystem || len(s.capabilities.AllowedPaths) > 0)
 }
 
 // ApplyResourceLimits is a no-op on macOS.

--- a/internal/plugin/sandbox/sandbox_darwin_test.go
+++ b/internal/plugin/sandbox/sandbox_darwin_test.go
@@ -1,0 +1,134 @@
+//go:build darwin
+
+package sandbox
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/relicta-tech/relicta/v4/internal/config"
+)
+
+func TestNeedsSeatbelt(t *testing.T) {
+	tests := []struct {
+		name string
+		caps *config.PluginCapabilities
+		want bool
+	}{
+		{"nil caps", nil, false},
+		{"fully permitted", &config.PluginCapabilities{AllowNetwork: true, AllowFilesystem: true}, false},
+		{"network denied", &config.PluginCapabilities{AllowNetwork: false, AllowFilesystem: true}, true},
+		{"filesystem denied", &config.PluginCapabilities{AllowNetwork: true, AllowFilesystem: false}, true},
+		{"path allowlist set", &config.PluginCapabilities{AllowNetwork: true, AllowFilesystem: true, AllowedPaths: []string{"/tmp/x"}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := needsSeatbelt(tt.caps); got != tt.want {
+				t.Fatalf("needsSeatbelt = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildSeatbeltProfile_Network(t *testing.T) {
+	denied := buildSeatbeltProfile(&config.PluginCapabilities{AllowNetwork: false, AllowFilesystem: true})
+	if !strings.Contains(denied, "(deny network-outbound)") {
+		t.Fatalf("network-denied profile must deny outbound, got:\n%s", denied)
+	}
+	if !strings.Contains(denied, `(allow network-outbound (remote ip "localhost:*"))`) {
+		t.Fatalf("must keep loopback for the gRPC handshake, got:\n%s", denied)
+	}
+
+	allowed := buildSeatbeltProfile(&config.PluginCapabilities{AllowNetwork: true, AllowFilesystem: true, AllowedPaths: []string{"/tmp/x"}})
+	if strings.Contains(allowed, "deny network-outbound") {
+		t.Fatalf("network-allowed profile must not deny outbound, got:\n%s", allowed)
+	}
+}
+
+func TestBuildSeatbeltProfile_FilesystemConfinesAllowedPaths(t *testing.T) {
+	profile := buildSeatbeltProfile(&config.PluginCapabilities{
+		AllowNetwork:    true,
+		AllowFilesystem: false,
+		AllowedPaths:    []string{"/opt/relicta/data"},
+	})
+	if !strings.Contains(profile, "(deny file-write*)") {
+		t.Fatalf("filesystem-restricted profile must deny writes, got:\n%s", profile)
+	}
+	if !strings.Contains(profile, `(allow file-write* (subpath "/opt/relicta/data"))`) {
+		t.Fatalf("allowed path must remain writable, got:\n%s", profile)
+	}
+	if !strings.Contains(profile, `(subpath "/private/tmp")`) {
+		t.Fatalf("temp must remain writable so the runtime works, got:\n%s", profile)
+	}
+}
+
+func TestWrapWithSeatbelt_RewritesCommand(t *testing.T) {
+	if !seatbeltAvailable() {
+		t.Skip("sandbox-exec not available")
+	}
+	s := New("test-plugin", &config.PluginCapabilities{AllowNetwork: false, AllowFilesystem: false})
+	cmd := exec.Command("/bin/echo", "hello")
+
+	s.wrapWithSeatbelt(cmd)
+
+	sbexec, _ := exec.LookPath("sandbox-exec")
+	if cmd.Path != sbexec {
+		t.Fatalf("cmd.Path = %s, want %s", cmd.Path, sbexec)
+	}
+	if len(cmd.Args) < 5 || cmd.Args[0] != sbexec || cmd.Args[1] != "-p" {
+		t.Fatalf("expected sandbox-exec -p <profile> wrapping, got args: %v", cmd.Args)
+	}
+	// Original binary and its args must be preserved after the profile.
+	if cmd.Args[3] != "/bin/echo" || cmd.Args[4] != "hello" {
+		t.Fatalf("original command not preserved, got args: %v", cmd.Args)
+	}
+}
+
+func TestWrapWithSeatbelt_NoOpWhenUnrestricted(t *testing.T) {
+	s := New("test-plugin", &config.PluginCapabilities{AllowNetwork: true, AllowFilesystem: true})
+	cmd := exec.Command("/bin/echo", "hello")
+	origPath := cmd.Path
+
+	s.wrapWithSeatbelt(cmd)
+
+	if cmd.Path != origPath {
+		t.Fatalf("unrestricted plugin must not be wrapped; cmd.Path = %s", cmd.Path)
+	}
+}
+
+// TestSeatbelt_EnforcesWriteConfinement runs sandbox-exec for real and proves the
+// generated profile actually denies a write outside the allowed set while
+// permitting one inside temp. The "outside" target lives under HOME (normally
+// writable), so a failure is attributable to the seatbelt, not to permissions.
+func TestSeatbelt_EnforcesWriteConfinement(t *testing.T) {
+	if !seatbeltAvailable() {
+		t.Skip("sandbox-exec not available")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+	outside := filepath.Join(home, ".relicta_seatbelt_test_artifact")
+	t.Cleanup(func() { _ = os.Remove(outside) })
+
+	profile := buildSeatbeltProfile(&config.PluginCapabilities{AllowNetwork: true, AllowFilesystem: false})
+
+	// Denied: write outside temp/allowed paths.
+	denyCmd := exec.Command("sandbox-exec", "-p", profile, "/bin/sh", "-c", "echo x > "+outside)
+	if err := denyCmd.Run(); err == nil {
+		t.Fatalf("seatbelt must deny write to %s", outside)
+	}
+	if _, statErr := os.Stat(outside); statErr == nil {
+		t.Fatalf("denied write must not create %s", outside)
+	}
+
+	// Allowed: write inside temp.
+	inside := filepath.Join(t.TempDir(), "ok.txt")
+	allowCmd := exec.Command("sandbox-exec", "-p", profile, "/bin/sh", "-c", "echo x > "+inside)
+	if err := allowCmd.Run(); err != nil {
+		t.Fatalf("seatbelt must permit write to temp %s: %v", inside, err)
+	}
+}

--- a/internal/plugin/sandbox/security_notice.go
+++ b/internal/plugin/sandbox/security_notice.go
@@ -12,9 +12,18 @@
 package sandbox
 
 import (
+	"os/exec"
 	"runtime"
 	"strings"
 )
+
+// seatbeltAvailable reports whether the macOS sandbox-exec binary is on PATH.
+// On non-darwin platforms it returns false (the binary does not exist), which is
+// harmless because the posture only consults it in the darwin branch.
+func seatbeltAvailable() bool {
+	_, err := exec.LookPath("sandbox-exec")
+	return err == nil
+}
 
 // EnforcementLevel ranks the strength of sandbox enforcement on this platform.
 type EnforcementLevel string
@@ -89,13 +98,24 @@ func CurrentPosture() SecurityPosture {
 		p.Level = EnforcementBestEffort
 		p.MemoryEnforced = false
 		p.CPUEnforced = false
-		p.FilesystemIsolated = false
+		// Filesystem/network confinement is enforced via a sandbox-exec seatbelt
+		// profile when the binary is available and the plugin's capabilities
+		// restrict access. Memory/CPU remain best-effort, so the overall level
+		// stays best_effort.
+		seatbelt := seatbeltAvailable()
+		p.FilesystemIsolated = seatbelt
 		p.Caveats = []string{
 			"On Apple Silicon (arm64), RLIMIT_AS is silently ignored by the kernel.",
-			"No sandbox-exec profile is generated; plugins run with the user's full filesystem access.",
 			"CPU caps are not enforced on macOS without launchd job control.",
-			"Primary protection is the per-plugin timeout in the plugin manager.",
+			"Primary protection against runaway plugins is the per-plugin timeout in the plugin manager.",
 			"Plugin signature verification is not yet implemented; only run trusted plugins.",
+		}
+		if seatbelt {
+			p.Caveats = append(p.Caveats,
+				"Network egress and filesystem writes are confined via a sandbox-exec profile when a plugin's capabilities restrict them (loopback and temp paths stay permitted).")
+		} else {
+			p.Caveats = append(p.Caveats,
+				"sandbox-exec was not found on PATH; plugins run with the user's full filesystem and network access.")
 		}
 
 	default:


### PR DESCRIPTION
## Summary

Independent of the governance work — branches off `main`. Closes the macOS sandbox gap from the tech-debt audit.

On macOS the plugin sandbox was **timeout-only**: `RLIMIT_AS` is a no-op on Apple Silicon and no `sandbox-exec` profile was generated, so plugins ran with the user's full network and filesystem access regardless of their declared capabilities.

## Change
Generate a seatbelt (SBPL) profile from the plugin's capabilities and wrap the launch in `sandbox-exec -p <profile>` when network or filesystem access is restricted. The profile is **allow-by-default**, then selectively denies:

- **Network** — denies outbound egress but keeps **loopback + unix sockets**, so the go-plugin gRPC handshake (127.0.0.1 / unix socket) still connects. This is the key insight that makes confinement compatible with the plugin transport.
- **Filesystem** — confines writes to system temp + explicitly-allowed paths; reads stay open so dylibs and the plugin binary load normally.

### Why not Docker/cgroups?
Relicta's value prop is single-binary distribution; adding a container-runtime dependency contradicts that. `sandbox-exec` is native, needs no deps, and provides real kernel enforcement. Memory/CPU limits remain best-effort on macOS (so the overall posture stays `best_effort`), but `CurrentPosture()` now reports filesystem isolation when sandbox-exec is available, and the caveats reflect reality.

### Graceful degradation
A missing `sandbox-exec` logs a warning and runs unconfined — consistent with the existing best-effort resource-limit posture.

## Tests
- `needsSeatbelt` / `buildSeatbeltProfile` / `wrapWithSeatbelt` unit coverage
- **Real enforcement test**: runs `sandbox-exec` with a generated profile and proves a write outside the allowed set is denied while a temp write succeeds (passes in CI on darwin; skips where sandbox-exec is absent)
- `go build ./...`, `go vet`, full sandbox package tests, `golangci-lint` 0 issues

No new dependencies.